### PR TITLE
Only run validation when a package is changed

### DIFF
--- a/.github/workflows/validate-mpackage.yml
+++ b/.github/workflows/validate-mpackage.yml
@@ -1,6 +1,8 @@
 name: Validate mpackage file
 
-on: pull_request
+on:
+  pull_request:
+    paths: packages/*.mpackage
 
 jobs:
   check-mpackage-contents:


### PR DESCRIPTION
Only run validation when a package is changed

See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore