### PR TITLE
Fix regex pattern in parseConfigLua function not to stop at apostrophes

### DIFF
--- a/upload-site/app/lib/packageParser.ts
+++ b/upload-site/app/lib/packageParser.ts
@@ -3,9 +3,9 @@ import { PackageMetadata } from '@/app/lib/types'
 export function parseConfigLua(content: string): PackageMetadata {
   // Helper function to safely extract values
   const extractValue = (pattern: string): string | null => {
-    const match = content.match(new RegExp(`${pattern}\\s*=\\s*(?:\\[\\[|["'])(.*?)(?:\\]\\]|["'])`, 'ms'))
+    const match = content.match(new RegExp(`${pattern} *= *(?:\\[\\[)(.*?)(?:\\]\\])`, 'ms'))
     return match ? match[1].trim() : null
-  }  
+  }
 
   return {
     mpackage: extractValue('mpackage'),
@@ -23,8 +23,8 @@ export function parseConfigLua(content: string): PackageMetadata {
 export function hasRequiredFields(metadata: PackageMetadata): boolean {
   // You can define which fields are absolutely required
   return Boolean(
-    metadata.mpackage && 
-    metadata.title && 
+    metadata.mpackage &&
+    metadata.title &&
     metadata.version
   )
 }


### PR DESCRIPTION
Fixes https://github.com/Mudlet/mudlet-package-repository/issues/162. Makes the regex pattern only accept `value = [[content]]`, not `value = 'content'` or `value = "content"`.

Ideally we'd [run the Lua interpreter](https://github.com/Mudlet/mudlet-package-repository/blob/main/.github/workflows/validate-mpackage.yml#L108-L109) to get these values, but that seems tricky to do in a pure NodeJS environment.

![image](https://github.com/user-attachments/assets/19c8fd90-51a4-4bec-8c52-8fca92e6386e)
