### PR TITLE
Fail fast on invalid utf8 in a packge

### DIFF
--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -34,6 +34,7 @@ jobs:
         luarocks install json-lua
         luarocks install luazip
         luarocks install luafilesystem
+        luarocks install lua-yajl
 
     # Fix timestamps
     - name: restore timestamps


### PR DESCRIPTION
Write the json file and validate it with yajl after every package - this way we can tell if a package breaks yajl before merging it, and know which one did it too.

Related to https://github.com/Mudlet/mudlet-package-repository/issues/159 but doesn't complete solve the problem yet.