### PR TITLE
Update package index workflow to include icon files in the commit

### DIFF
--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -47,4 +47,4 @@ jobs:
     - uses: stefanzweifel/git-auto-commit-action@v5        
       with:
         commit_message: Automated package index update.
-        file_pattern: 'packages/*.packages.json'
+        file_pattern: 'packages/*.packages.json upload-site/public/icons/*'


### PR DESCRIPTION
Needed for https://github.com/Mudlet/mudlet-package-repository/pull/190 which added an icon file - which is being extracted successfully, but not actually committed.

