### PR TITLE
Fix package upload

### DIFF
--- a/upload-site/app/lib/packageParser.ts
+++ b/upload-site/app/lib/packageParser.ts
@@ -7,11 +7,16 @@ export function parseConfigLua(content: string): PackageMetadata {
     return match ? match[1].trim() : null
   }
 
+  const extractCreatedDate = (): string | null => {
+    const match = content.match(new RegExp(`created *= *(?:")(.*?)(?:")`, 'ms'))
+    return match ? match[1].trim() : null
+  }
+
   return {
     mpackage: extractValue('mpackage'),
     title: extractValue('title'),
     version: extractValue('version'),
-    created: extractValue('created'),
+    created: extractCreatedDate(),
     author: extractValue('author'),
     description: extractValue('description'),
     icon: extractValue('icon'),

--- a/upload-site/app/lib/packageParser.ts
+++ b/upload-site/app/lib/packageParser.ts
@@ -3,12 +3,8 @@ import { PackageMetadata } from '@/app/lib/types'
 export function parseConfigLua(content: string): PackageMetadata {
   // Helper function to safely extract values
   const extractValue = (pattern: string): string | null => {
-    const match = content.match(new RegExp(`${pattern} *= *(?:\\[\\[)(.*?)(?:\\]\\])`, 'ms'))
-    return match ? match[1].trim() : null
-  }
-
-  const extractCreatedDate = (): string | null => {
-    const match = content.match(new RegExp(`created *= *(?:")(.*?)(?:")`, 'ms'))
+    const match = content.match(new RegExp(`${pattern} *= *(?:\\[\\[)(.*?)(?:\\]\\])`, 'ms')) ||
+                  content.match(new RegExp(`${pattern} *= *(?:")(.*?)(?:")`, 'ms'))
     return match ? match[1].trim() : null
   }
 
@@ -16,7 +12,7 @@ export function parseConfigLua(content: string): PackageMetadata {
     mpackage: extractValue('mpackage'),
     title: extractValue('title'),
     version: extractValue('version'),
-    created: extractCreatedDate(),
+    created: extractValue('created'),
     author: extractValue('author'),
     description: extractValue('description'),
     icon: extractValue('icon'),


### PR DESCRIPTION
`created` field extraction broke with https://github.com/Mudlet/mudlet-package-repository/pull/189 - sometimes it comes in this format:

```
created = [[2024-11-26T22:50:47+0000]]
```

And sometimes in this:

```
created = "2025-01-20T00:05:07+08:00"
```

This fixes it to work with both.

Before fix:

![image](https://github.com/user-attachments/assets/93fe883a-fcd1-421f-b307-391b8b83bc4e)

After fix:

![image](https://github.com/user-attachments/assets/d16983c3-d17d-40ac-88e0-9f977b5ed01e)
