### PR TITLE
Remove user name from package update and signin message

### DIFF
--- a/upload-site/app/api/upload/route.ts
+++ b/upload-site/app/api/upload/route.ts
@@ -99,7 +99,6 @@ export async function POST(request: Request) {
 - Title: ${metadata.title}
 - Version: ${metadata.version}
 - Author: ${metadata.author}
-- Package ${existingPackage ? 'updated' : 'added'} by ${session.user?.name || 'unknown user'}
 - Created: ${metadata.created}
 
 ---

--- a/upload-site/app/components/Auth.tsx
+++ b/upload-site/app/components/Auth.tsx
@@ -8,7 +8,7 @@ export const Auth = () => {
   if (session) {
     return (
       <div className="flex items-center gap-4 py-4">
-        <span className="text-gray-700">Welcome, {session.user?.name}</span>
+        <span className="text-gray-700">Welcome</span>
         <button
           onClick={() => signOut()}
           className="px-4 py-2 text-sm bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-md transition-colors"


### PR DESCRIPTION
Remove user name from package update and signin message - in retrospect, putting folks' names out there is not a good idea.

The original intent was to keep track of bad actors, but we'll think on a better mechanism in the future.