### PR TITLE
Fix icon path in metadata extraction for preview route

### DIFF
--- a/upload-site/app/api/preview/route.ts
+++ b/upload-site/app/api/preview/route.ts
@@ -97,7 +97,7 @@ export async function POST(request: Request) {
 
   // Extract icon if specified in metadata
   if (metadata.icon) {
-    const iconEntry = zip.getEntry(metadata.icon)
+    const iconEntry = zip.getEntry(`.mudlet/Icon/${metadata.icon}`)
     if (iconEntry) {
       const extension = metadata.icon.match(/\.[^.]+$/)?.[0] || '.png'
       const iconData = iconEntry.getData()
@@ -107,7 +107,7 @@ export async function POST(request: Request) {
       metadata.icon = null
     }
   }
-
+  
   const validation = await validateMetadata(metadata)
 
   return NextResponse.json({


### PR DESCRIPTION
Fix icon path in metadata extraction for preview route - now properly works for icons with spaces in them. It was a bit of a fluke that it worked before, really!

![image](https://github.com/user-attachments/assets/62fbfcd5-5d79-40f3-8abb-76a24ac757d0)
