### PR TITLE
Don't rebuild indexes in forks

### DIFF
--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -1,4 +1,4 @@
-name: Create json index
+name: Refresh json index
 on:
   push:
     branches: 
@@ -10,6 +10,7 @@ on:
 jobs:
   reindex-json-file:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Mudlet' }}
 
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the


### PR DESCRIPTION
Don't rebuild indexes in forks - because that messes up syncronising the fork a bit every time, as both Mudlet repo and the fork have separate commits that are unrelated to each other.

