### PR TITLE
Fix icons

### DIFF
--- a/upload-site/app/components/PackageList.tsx
+++ b/upload-site/app/components/PackageList.tsx
@@ -68,7 +68,7 @@ export const PackageList = ({ packages, limit }: PackageListProps) => {
               {pkg.icon && (
                 <div className="flex-shrink-0">
                   <Image
-                    src={`https://github.com/Mudlet/mudlet-package-repository/blob/refs/heads/main/${pkg.icon}`}
+                    src={`https://raw.githubusercontent.com/Mudlet/mudlet-package-repository/refs/heads/main/${pkg.icon}`}
                     alt={`${pkg.mpackage} icon`}
                     width={48}
                     height={48}

--- a/upload-site/next.config.ts
+++ b/upload-site/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'github.com',
+        hostname: 'raw.githubusercontent.com',
         pathname: '/Mudlet/mudlet-package-repository/**',
       },
     ],


### PR DESCRIPTION
Links need to be on raw.githubusercontent.com, otherwise github previews them