### PR TITLE
Remove all mudlet.github.io links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This Github repository hosts packages made for the Mudlet MUD client.  It is als
 mpkg comes preinstalled on later (4.20+) versions of Mudlet.  If you do not have it, consider upgrading or
 issue this command on any profile you wish to use mpkg with.
 
-```lua installPackage("https://mudlet.github.io/mudlet-package-repository/packages/mpkg.mpackage")```
+```lua installPackage("https://github.com/Mudlet/mudlet-package-repository/raw/refs/heads/main/packages/mpkg.mpackage")```
 
 Then on the command line you can issue any of the following commands.
 

--- a/mpkg/README.md
+++ b/mpkg/README.md
@@ -15,4 +15,3 @@ Commands:
 ### See Also
 
 * https://packages.mudlet.org
-* https://mudlet.github.io/mudlet-package-repository/

--- a/upload-site/app/components/IntroSection.tsx
+++ b/upload-site/app/components/IntroSection.tsx
@@ -15,7 +15,7 @@ export function IntroSection() {
         <h2 className="text-2xl font-semibold mb-4">Installation</h2>
         <p className="mb-4">To access this website from within Mudlet, copy/paste the following to your command line:</p>
         <pre className="bg-gray-100 p-4 rounded-lg mb-4 overflow-x-auto">
-          <code>lua installPackage("https://mudlet.github.io/mudlet-package-repository/packages/mpkg.mpackage")</code>
+          <code>lua installPackage("https://github.com/Mudlet/mudlet-package-repository/raw/refs/heads/main/packages/mpkg.mpackage")</code>
         </pre>
       </section>
 

--- a/upload-site/app/components/PackageList.tsx
+++ b/upload-site/app/components/PackageList.tsx
@@ -46,7 +46,7 @@ export const PackageList = ({ packages, limit }: PackageListProps) => {
               <div className="flex-grow">
                 <h2 className="text-xl font-semibold mb-2">
                   <a
-                    href={`https://mudlet.github.io/mudlet-package-repository/packages/${pkg.filename}`}
+                    href={`https://github.com/Mudlet/mudlet-package-repository/raw/refs/heads/main/packages/${pkg.filename}`}
                     className="text-blue-600 hover:text-blue-800 focus:ring-2 focus:ring-blue-500 focus:outline-none"
                     onClick={(e) => e.stopPropagation()}
                     aria-label={`Download ${pkg.mpackage} package`}

--- a/upload-site/app/lib/packages.ts
+++ b/upload-site/app/lib/packages.ts
@@ -1,7 +1,7 @@
 import { PackageMetadata } from './types'
 
 export async function fetchRepositoryPackages(): Promise<PackageMetadata[]> {
-  const response = await fetch('https://mudlet.github.io/mudlet-package-repository/packages/mpkg.packages.json')
+  const response = await fetch('https://raw.githubusercontent.com/Mudlet/mudlet-package-repository/refs/heads/main/packages/mpkg.packages.json')
   const data = await response.json()
   return data.packages
 }

--- a/upload-site/app/page.tsx
+++ b/upload-site/app/page.tsx
@@ -10,7 +10,7 @@ const getPackages = async () => {
     const jsonData = await fs.readFile('../packages/mpkg.packages.json', 'utf8');
     return JSON.parse(jsonData).packages;
   }
-  const response = await fetch('https://mudlet.github.io/mudlet-package-repository/packages/mpkg.packages.json');
+  const response = await fetch('https://raw.githubusercontent.com/Mudlet/mudlet-package-repository/refs/heads/main/packages/mpkg.packages.json');
   const data = await response.json();
   return data.packages;
 };


### PR DESCRIPTION
Remove all mudlet.github.io links - they are no longer so active, and it might help keeping the package count on the homepage fresh.