### PR TITLE
Remove aria-expanded attribute from PackageList component per player feedback

### DIFF
--- a/upload-site/app/components/PackageList.tsx
+++ b/upload-site/app/components/PackageList.tsx
@@ -38,7 +38,6 @@ export const PackageList = ({ packages, limit }: PackageListProps) => {
               }
             }}
             role="button"
-            aria-expanded={expandedPackage === pkg.mpackage}
             aria-controls={`description-${pkg.mpackage}`}
             tabIndex={0}
           >


### PR DESCRIPTION
@ironcross32 mentioned it is actually triggering too often for him.