### PR TITLE
Enhance PackagePreview component with Markdown support for description

### DIFF
--- a/upload-site/app/components/PackagePreview.tsx
+++ b/upload-site/app/components/PackagePreview.tsx
@@ -1,6 +1,8 @@
 import { PackageMetadata } from '@/app/lib/types'
 import { ValidationResult } from '@/app/lib/types'
 import Image from 'next/image'
+import ReactMarkdown from 'react-markdown'
+
 
 interface PackagePreviewProps {
   metadata: PackageMetadata
@@ -44,7 +46,7 @@ export function PackagePreview({
   return (
     <div className="border rounded-lg p-6 bg-background">
       <h2 className="text-2xl font-bold mb-4">Package preview</h2>
-      
+
       <div className="space-y-4 mb-6">
         <div className="grid grid-cols-[120px,1fr] gap-2">
           <div className="flex items-center">
@@ -52,69 +54,69 @@ export function PackagePreview({
           </div>
           <p className="break-all">{filename}</p>
         </div>
-        
+
         <div className="grid grid-cols-[120px,1fr] gap-2">
           <div className="flex items-center">
             <label className="font-semibold">Name:</label>
-            {getFieldStatus('mpackage')}
+            {getFieldStatus("mpackage")}
           </div>
           <div className="flex items-center">
             <p className="break-all">{metadata.mpackage}</p>
-            {validation.missingFields.includes('mpackage') && 
+            {validation.missingFields.includes("mpackage") && (
               <span className="text-red-500">(required)</span>
-            }
+            )}
           </div>
         </div>
 
         <div className="grid grid-cols-[120px,1fr] gap-2">
           <div className="flex items-center">
             <label className="font-semibold">Title:</label>
-            {getFieldStatus('title')}
+            {getFieldStatus("title")}
           </div>
           <div className="flex items-center">
             <p className="break-all">{metadata.title}</p>
-            {validation.missingFields.includes('title') && 
+            {validation.missingFields.includes("title") && (
               <span className="text-red-500">(required)</span>
-            }
+            )}
           </div>
         </div>
 
         <div className="grid grid-cols-[120px,1fr] gap-2">
           <div className="flex items-center">
             <label className="font-semibold">Version:</label>
-            {getFieldStatus('version')}
+            {getFieldStatus("version")}
           </div>
           <div className="flex items-center">
             <p>{metadata.version}</p>
-            {validation.missingFields.includes('version') && 
+            {validation.missingFields.includes("version") && (
               <span className="text-red-500">(required)</span>
-            }
+            )}
           </div>
         </div>
 
         <div className="grid grid-cols-[120px,1fr] gap-2">
           <div className="flex items-center">
             <label className="font-semibold">Author:</label>
-            {getFieldStatus('author')}
+            {getFieldStatus("author")}
           </div>
           <div className="flex items-center">
             <p>{metadata.author}</p>
-            {validation.missingFields.includes('author') && 
+            {validation.missingFields.includes("author") && (
               <span className="text-red-500">(required)</span>
-            }
+            )}
           </div>
         </div>
 
         <div className="grid grid-cols-[120px,1fr] gap-2">
           <div className="flex items-center">
             <label className="font-semibold">Created:</label>
-            {getFieldStatus('created')}
+            {getFieldStatus("created")}
           </div>
           <div className="flex items-center">
             <p>{metadata.created}</p>
-            {validation.missingFields.includes('created') && 
+            {validation.missingFields.includes("created") && (
               <span className="text-red-500">(required)</span>
-            }
+            )}
           </div>
         </div>
 
@@ -140,13 +142,17 @@ export function PackagePreview({
         <div className="grid grid-cols-[120px,1fr] gap-2">
           <div className="flex items-center">
             <label className="font-semibold">Description:</label>
-            {getFieldStatus('description')}
+            {getFieldStatus("description")}
           </div>
           <div className="flex items-center">
-            <p className="whitespace-pre-wrap break-words">{metadata.description}</p>
-            {validation.missingFields.includes('description') && 
+            <div className="mt-4 description-container">
+              <ReactMarkdown className="prose prose-blue max-w-none prose-sm">
+                {metadata.description}
+              </ReactMarkdown>
+            </div>
+            {validation.missingFields.includes("description") && (
               <span className="text-red-500">(required)</span>
-            }
+            )}
           </div>
         </div>
       </div>
@@ -163,33 +169,38 @@ export function PackagePreview({
           </div>
         )}
         <div className="flex gap-4">
-          <button 
+          <button
             onClick={onConfirm}
             disabled={isUploading || !validation.isValid}
             className={`
               px-4 py-2 rounded text-white
-              ${isUploading || !validation.isValid
-                ? 'bg-green-400 cursor-not-allowed' 
-                : 'bg-green-600 hover:bg-green-700'
+              ${
+                isUploading || !validation.isValid
+                  ? "bg-green-400 cursor-not-allowed"
+                  : "bg-green-600 hover:bg-green-700"
               }
               flex items-center gap-2
             `}
-            title={!validation.isValid ? `${getMissingFieldsMessage()} ${getValidationErrorsMessage()}` : 'Confirm upload'}
+            title={
+              !validation.isValid
+                ? `${getMissingFieldsMessage()} ${getValidationErrorsMessage()}`
+                : "Confirm upload"
+            }
           >
             {isUploading ? (
               <>
                 <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
-                  <circle 
-                    className="opacity-25" 
-                    cx="12" 
-                    cy="12" 
-                    r="10" 
-                    stroke="currentColor" 
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
                     strokeWidth="4"
                     fill="none"
                   />
-                  <path 
-                    className="opacity-75" 
+                  <path
+                    className="opacity-75"
                     fill="currentColor"
                     d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                   />
@@ -197,18 +208,19 @@ export function PackagePreview({
                 Uploading...
               </>
             ) : (
-              'Confirm upload'
+              "Confirm upload"
             )}
           </button>
-          
-          <button 
+
+          <button
             onClick={onCancel}
             disabled={isUploading}
             className={`
               px-4 py-2 rounded text-white
-              ${isUploading 
-                ? 'bg-gray-400 cursor-not-allowed' 
-                : 'bg-gray-600 hover:bg-gray-700'
+              ${
+                isUploading
+                  ? "bg-gray-400 cursor-not-allowed"
+                  : "bg-gray-600 hover:bg-gray-700"
               }
             `}
           >
@@ -217,5 +229,5 @@ export function PackagePreview({
         </div>
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
It wasn't being shown before, making it hard to tweak the description to exactly what you'd like.

Now it does this:

![image](https://github.com/user-attachments/assets/71bede18-6d26-4019-8da3-9a66746f8a05)
