### PR TITLE
Improve upload form for slow connections

### DIFF
--- a/upload-site/app/components/PackagePreview.tsx
+++ b/upload-site/app/components/PackagePreview.tsx
@@ -36,7 +36,6 @@ export function PackagePreview({
 
   const getValidationErrorsMessage = () => {
     return Object.entries(validation.fieldErrors)
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .map(([field, errors]) => errors.join(', '))
       .join(', ')
   }


### PR DESCRIPTION
Improve upload form for slow connections - in case you are on a slow connection or uploading a large package, the form would not react at all for a long while. Now, if things are taking longer than expected, it says `Loading preview...`:

[Screencast from 2025-01-26 21-37-17.webm](https://github.com/user-attachments/assets/4cc65e3f-c7ad-4971-a7d8-0a8fbec42f01)
