### PR TITLE
Implementing #441 via clickable sanitized anchor links

### DIFF
--- a/upload-site/app/components/PackageList.tsx
+++ b/upload-site/app/components/PackageList.tsx
@@ -38,6 +38,7 @@ export const PackageList = ({ packages, limit }: PackageListProps) => {
         {displayPackages.map((pkg) => (
           <article
             key={pkg.mpackage}
+            id={`pkg-${encodeURIComponent(pkg.mpackage || '')}`}
             className="bg-white rounded-lg shadow hover:shadow-md transition-shadow cursor-pointer p-4 mb-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
             onClick={() => toggleExpand(pkg.mpackage)}
             onKeyDown={(e) => {
@@ -50,7 +51,7 @@ export const PackageList = ({ packages, limit }: PackageListProps) => {
             aria-controls={`description-${pkg.mpackage}`}
             tabIndex={0}
           >
-            <div className="flex items-start justify-between gap-4">
+            <div className="flex items-start justify-between gap-4 items-stretch">
               <div className="flex-grow">
                 <h2 className="text-xl font-semibold mb-2">
                   <a
@@ -73,17 +74,25 @@ export const PackageList = ({ packages, limit }: PackageListProps) => {
                 </p>
                 <p className="text-gray-800">{pkg.title}</p>
               </div>
-              {pkg.icon && (
-                <div className="flex-shrink-0">
-                  <Image
-                    src={`https://raw.githubusercontent.com/Mudlet/mudlet-package-repository/refs/heads/main/${pkg.icon}`}
-                    alt={`${pkg.mpackage} icon`}
-                    width={48}
-                    height={48}
-                    className="rounded"
-                  />
-                </div>
-              )}
+              <div className="flex-shrink-0 flex flex-col">
+                  {pkg.icon && (
+                    <Image
+                      src={`https://raw.githubusercontent.com/Mudlet/mudlet-package-repository/refs/heads/main/${pkg.icon}`}
+                      alt={`${pkg.mpackage} icon`}
+                      width={48}
+                      height={48}
+                      className="rounded flex-shrink-0"
+                    />
+                  )}
+                  <div className="content-end flex-grow-2">
+                    <p className="text-gray-600 text-right">
+                      <a href={`#pkg-${encodeURIComponent(pkg.mpackage || '')}`}>link</a>
+                    </p>
+                  </div>
+                  
+              </div>
+              
+              
             </div>
             {expandedPackage === pkg.mpackage && (
               <div

--- a/upload-site/app/components/PackageList.tsx
+++ b/upload-site/app/components/PackageList.tsx
@@ -8,9 +8,10 @@ import Image from 'next/image'
 interface PackageListProps {
   packages: PackageMetadata[];
   limit?: number;
+  hideLinks?: boolean;
 }
 
-export const PackageList = ({ packages, limit }: PackageListProps) => {
+export const PackageList = ({ packages, limit, hideLinks }: PackageListProps) => {
   const [expandedPackage, setExpandedPackage] = useState<string | null>(null);
 
   // Sort packages alphabetically by mpackage, case-insensitive
@@ -31,6 +32,8 @@ export const PackageList = ({ packages, limit }: PackageListProps) => {
   const toggleExpand = (mpackage: string | null) => {
     setExpandedPackage(expandedPackage === mpackage ? null : mpackage);
   };
+
+  const _showLinks = hideLinks ? false : true;
 
   return (
     <section className="page-content" aria-label="Package listings">
@@ -84,11 +87,13 @@ export const PackageList = ({ packages, limit }: PackageListProps) => {
                       className="rounded flex-shrink-0"
                     />
                   )}
-                  <div className="content-end flex-grow-2">
-                    <p className="text-gray-600 text-right">
-                      <a href={`#pkg-${encodeURIComponent(pkg.mpackage || '')}`}>link</a>
-                    </p>
-                  </div>
+                  {_showLinks && (
+                    <div className="content-end flex-grow-2">
+                      <p className="text-gray-600 text-right">
+                        <a href={`#pkg-${encodeURIComponent(pkg.mpackage || '')}`}>link</a>
+                      </p>
+                    </div>
+                  )}
                   
               </div>
               

--- a/upload-site/app/globals.css
+++ b/upload-site/app/globals.css
@@ -30,3 +30,19 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+.items-stretch {
+  align-items: stretch;
+}
+
+.flex-grow-2 {
+  flex-grow: 2;
+}
+
+.content-end {
+  align-content: end;
+}
+
+.text-right {
+  text-align: right;
+}

--- a/upload-site/app/page.tsx
+++ b/upload-site/app/page.tsx
@@ -34,7 +34,7 @@ export default async function Home() {
       </div>
       <div className="border-t pt-8">
         <h2 className="text-2xl font-bold mb-8">Recent uploads</h2>
-        <PackageList packages={packages} limit={5} />
+        <PackageList packages={packages} limit={5} hideLinks={true} />
       </div>
     </main>
   );


### PR DESCRIPTION
Long story short, all of the package divs have a sanitized version of their `mpackage` value as their `id`, and each of these divs has a clickable link on them to themselves (taking advantage of anchor links).

The practical upshot of which being that you can easily obtain and then share a link to a package, like so: <https://packages.mudlet.org/packages#pkg-MUDKIP_Mud2> (or <http://localhost:3000/packages#pkg-MUDKIP_Mud2> if you're running a development build locally).

Current implementation does look a *bit* scuffed (see below screenshot with badly-drawn red circle around a link), but main thing is that it works.

![An image of what the implementation looks like](https://github.com/user-attachments/assets/ce4ce3c8-d2dc-4be0-9b5d-d147431ef279)

* Improvements that may be worth considering later on (by someone who actually knows what they're doing with frontend stuff)
  * Auto-expanding the linked package if a user opens the webpage via the package link.
  * Making the links look less scuffed (maybe a share/link svg icon instead of text?)
