### PR TITLE
Fix generic_mapper URL in core-package sync

### DIFF
--- a/.github/workflows/update-core-packages.yml
+++ b/.github/workflows/update-core-packages.yml
@@ -14,23 +14,29 @@ jobs:
         package:
           - name: deleteOldProfiles
             description: "Delete Old Profiles package"
+            path: src/deleteOldProfiles.mpackage
           - name: echo
             description: "Echo package"
+            path: src/echo.mpackage
           - name: enable-accessibility
             description: "Enable Accessibility package"
+            path: src/enable-accessibility.mpackage
           - name: run-lua-code
             description: "Run Lua Code package"
+            path: src/run-lua-code.mpackage
           - name: generic_mapper
             description: "Generic Mapper package"
+            path: src/mudlet-lua/lua/generic-mapper/generic_mapper.mpackage
           # - name: gui-drop
           #   description: "GUI Drop package"
+          #   path: src/mudlet-lua/lua/gui-drop/gui-drop.mpackage
     steps:
       - uses: actions/checkout@v4
 
       - name: Download ${{ matrix.package.name }} package
         uses: carlosperate/download-file-action@v2.0.2
         with:
-          file-url: https://raw.githubusercontent.com/Mudlet/Mudlet/development/src/${{ matrix.package.name }}.mpackage
+          file-url: https://raw.githubusercontent.com/Mudlet/Mudlet/development/${{ matrix.package.path }}
           file-name: ${{ matrix.package.name }}.mpackage
           location: packages/
 


### PR DESCRIPTION
The weekly core-package sync built every download URL as `src/<name>.mpackage`, but generic_mapper lives at `src/mudlet-lua/lua/generic-mapper/generic_mapper.mpackage` in Mudlet/Mudlet, so its download 404'd and the repository's copy sat at 2.1.3 while in-tree moved on (discovered while preparing #720). Each matrix entry now carries its explicit source path, verified to resolve for all five packages; the commented-out gui-drop entry had the same latent problem and its path is corrected too.

Related: #720