### PR TITLE
Infrastructure: keep mudlet-base-ui in sync with Mudlet

### DIFF
--- a/.github/workflows/update-core-packages.yml
+++ b/.github/workflows/update-core-packages.yml
@@ -27,6 +27,9 @@ jobs:
           - name: generic_mapper
             description: "Generic Mapper package"
             path: src/mudlet-lua/lua/generic-mapper/generic_mapper.mpackage
+          - name: mudlet-base-ui
+            description: "Mudlet base UI package"
+            path: src/mudlet-lua/lua/base-ui/mudlet-base-ui.mpackage
           # - name: gui-drop
           #   description: "GUI Drop package"
           #   path: src/mudlet-lua/lua/gui-drop/gui-drop.mpackage


### PR DESCRIPTION
Adds `mudlet-base-ui` to the weekly core-package sync, so the repository copy tracks `src/mudlet-lua/lua/base-ui/mudlet-base-ui.mpackage` on Mudlet `development` the same way `generic_mapper` and friends do.

Depends on #741, which seeds the file - with that merged first this job sees no changes until Mudlet updates the package.

Assisted-by: Claude:claude-opus-5