### PR TITLE
fix: a background package listing update no longer reports its failure

### DIFF
--- a/mpkg/mfile
+++ b/mpkg/mfile
@@ -2,7 +2,7 @@
        "package": "mpkg",
        "title": "A command line package manager for Mudlet.",
        "description": "",
-       "version": "3.4",
+       "version": "3.5",
        "author": "Mudlet Default Package",
        "icon": "mudlet-package-repo.png",
        "dependencies": "",

--- a/mpkg/src/scripts/Mudlet_Package_Manager_CLI.lua
+++ b/mpkg/src/scripts/Mudlet_Package_Manager_CLI.lua
@@ -409,6 +409,8 @@ function mpkg.updatePackageList(silent)
     mpkg.echo("Updating package listing from repository.")
     mpkg.displayUpdateMessage = true
     mpkg.silentFailures = nil
+  else
+    mpkg.silentFailures = true
   end
 end
 

--- a/mpkg/src/scripts/Mudlet_Package_Manager_CLI.lua
+++ b/mpkg/src/scripts/Mudlet_Package_Manager_CLI.lua
@@ -408,9 +408,7 @@ function mpkg.updatePackageList(silent)
   if not silent then
     mpkg.echo("Updating package listing from repository.")
     mpkg.displayUpdateMessage = true
-    mpkg.silentFailures = nil
-  else
-    mpkg.silentFailures = true
+    mpkg.reportDownloadFailure = true
   end
 end
 
@@ -600,14 +598,16 @@ end
 function mpkg.eventHandler(event, ...)
 
   if event == "sysDownloadError" and string.ends(arg[2], mpkg.filename) then
-    if not mpkg.silentFailures then
+    if mpkg.reportDownloadFailure then
       mpkg.echo("Failed to download package listing.")
-      mpkg.silentFailures = true
+      mpkg.reportDownloadFailure = nil
     end
     return
   end
 
   if event == "sysDownloadDone" and arg[1] == getMudletHomeDir() .. "/" .. mpkg.filename then
+
+    mpkg.reportDownloadFailure = nil
 
     if mpkg.displayUpdateMessage then
       mpkg.echo("Package listing downloaded.")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `mpkg.updatePackageList(silent)` now honours `silent` on the error path, so a background refresh that fails no longer writes to the game console.
- `mfile` version 3.4 → 3.5 so installed copies are offered the fix.

#### Motivation

mpkg is pre-installed into every Mudlet profile (`src/mudlet.cpp:7507`, applied to `*`). On profile load it refreshes the package listing **silently**, and again every 12 hours via a named timer:

```lua
registerNamedTimer("mpkg", "mpkg update package listing timer", 43200, function() mpkg.updatePackageList(true) end, true)
mpkg.updatePackageList(true)
```

But `silent` only suppressed the *progress* message. `mpkg.silentFailures` was cleared solely inside the `if not silent` branch, and set only *after* an error had already been echoed — so a silent update that could not reach the repository still printed to the console:

```
[ MPKG ]  - Failed to download package listing.
```

Anyone offline, behind a firewall or proxy, or hitting a GitHub outage saw that on every profile open, for an operation they never requested, in a console where it reads like a game or Mudlet error.

An explicit `mpkg update` still reports failure, since that path takes the `if not silent` branch and clears the flag.

#### Other info

Reported as Mudlet/Mudlet#9994.

**Why the version bump.** mpkg is a *versioned* package, so `getInstalledVersion("mpkg")` returns a real version and the semver comparison works — the bump is what makes installed copies eligible to be offered the fix. (The `mpkg.whitelist` is for non-versioned default packages and is not involved.) Without it, the fix would only reach newly created profiles via Mudlet's bundled copy, since Mudlet's `setupPreInstallPackages()` runs for new profiles only.

**No archive in this PR.** `muddle-mpkg.yml` builds `packages/mpkg.mpackage` from `mpkg/*` and auto-commits it, so building it by hand here would fight that job. Note the workflow is gated on `github.repository_owner == 'Mudlet'`, so it does not run on a fork — the rebuilt archive will appear after this merges, and then reaches Mudlet through its weekly `update-3rdparty.yml` vendoring PR.

**Test case:**

The change is three lines of flag handling, and I could not exercise this exact artifact locally because the archive only exists once muddler has run. What I can offer:

- The patched script parses cleanly under Lua 5.1, as does the unmodified baseline, so no syntax regression.
- `mfile` is what muddler turns into the archive's `config.lua` (matching `mpackage`/`title`/`version`/`author`/`icon` fields), so the bump lands in the built package.
- The identical two-line change, applied to the extracted `mpkg.xml`, rebuilt into an archive and compiled into Mudlet, took `TOscTest` from **3 of 5 runs failing** to **6 of 6 passing with zero `MPKG` output** — that test asserts on console text and was being corrupted by this message arriving asynchronously. It is corroboration via a different build path rather than a test of this patch.