### PR TITLE
Prerender package pages from the checkout

### DIFF
--- a/upload-site/app/components/Auth.tsx
+++ b/upload-site/app/components/Auth.tsx
@@ -6,7 +6,14 @@ const buttonClass =
   'rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60'
 
 export const Auth = () => {
-  const { data: session } = useSession()
+  const { data: session, status } = useSession()
+
+  // The session is fetched by the browser rather than rendered in (see
+  // SessionProvider), so hold the control's space until it lands instead of
+  // showing a signed-out button to someone who is signed in.
+  if (status === 'loading') {
+    return <div className="h-8 w-20 animate-pulse rounded-lg bg-surface-muted" aria-hidden="true" />
+  }
 
   if (session) {
     const name = session.user?.name || session.user?.email

--- a/upload-site/app/components/SessionProvider.tsx
+++ b/upload-site/app/components/SessionProvider.tsx
@@ -1,14 +1,16 @@
 'use client'
 
 import { SessionProvider as Provider } from "next-auth/react"
-import { Session } from "next-auth"
 
-export const SessionProvider = ({ children, session }: {
-  children: React.ReactNode,
-  session: Session | null
-}) => {
+/**
+ * Client boundary for next-auth. The session is deliberately *not* handed down
+ * from the server: reading it in the root layout made every route in the app
+ * dynamic, package pages included. It is fetched here instead, which only the
+ * header's sign-in control waits on - see Auth.
+ */
+export const SessionProvider = ({ children }: { children: React.ReactNode }) => {
   return (
-    <Provider session={session}>
+    <Provider>
       {children}
     </Provider>
   )

--- a/upload-site/app/layout.tsx
+++ b/upload-site/app/layout.tsx
@@ -1,6 +1,5 @@
 import './globals.css'
 import { Inter, JetBrains_Mono } from 'next/font/google'
-import { getServerSession } from 'next-auth'
 import Link from 'next/link'
 import { Auth } from './components/Auth'
 import { Navigation } from './components/Navigation'
@@ -24,18 +23,22 @@ export const metadata: Metadata = {
   }
 }
 
-export default async function RootLayout({
+/**
+ * Nothing here reads the session on the server. Doing so - it used to call
+ * getServerSession() for the SessionProvider's initial value - reads cookies,
+ * and a root layout that reads cookies makes every route in the app dynamic,
+ * which is what kept package pages from prerendering at all.
+ */
+export default function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const session = await getServerSession()
-
   return (
     <html lang="en" suppressHydrationWarning className={`${inter.variable} ${jetbrainsMono.variable}`}>
       <body className="font-sans">
         <ThemeProvider>
-          <SessionProvider session={session}>
+          <SessionProvider>
             <header className="sticky top-0 z-40 border-b border-border bg-surface/85 backdrop-blur">
               <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-2.5">
                 <div className="flex items-center gap-2 sm:gap-6">

--- a/upload-site/app/lib/packageArchive.ts
+++ b/upload-site/app/lib/packageArchive.ts
@@ -1,5 +1,5 @@
 import AdmZip from 'adm-zip'
-import { fetchPackageArchive } from './packages'
+import { fetchPackageArchive, readsFromCheckout } from './packages'
 
 /**
  * Reading one file out of a package means having the whole archive, and the
@@ -29,6 +29,11 @@ function forget(filename: string, entry: CacheEntry) {
 }
 
 export async function getArchiveBuffer(filename: string): Promise<Buffer> {
+  // Off the checkout an archive costs a local read, and the caller is usually
+  // the build prerendering all 200-odd package pages in turn - so retaining up
+  // to 96 MB of them buys nothing and only pressures the build worker.
+  if (readsFromCheckout) return fetchPackageArchive(filename)
+
   const cached = cache.get(filename)
   if (cached) {
     if (Date.now() - cached.storedAt < MAX_CACHE_AGE_MS) {

--- a/upload-site/app/lib/packages.ts
+++ b/upload-site/app/lib/packages.ts
@@ -1,18 +1,38 @@
-import { promises as fs } from 'fs'
+import { existsSync, promises as fs } from 'fs'
 import path from 'path'
 import { UploadedPackageMetadata } from './types'
 import { RAW_BASE, packageDownloadUrl, packageSlug } from './urls'
 
 const INDEX_URL = `${RAW_BASE}/packages/mpkg.packages.json`
 
-/** In dev the repository checkout sits one level up, so read it straight off disk. */
-const isDev = process.env.NODE_ENV === 'development'
-const localRepoPath = (...parts: string[]) => path.join(process.cwd(), '..', ...parts)
+/**
+ * The site is deployed out of the package repository itself, so the index and
+ * the archives sit one directory up from the Next.js root - during the Vercel
+ * build just as much as in dev. Reading them off disk is what lets package
+ * pages prerender (see generateStaticParams in app/packages/[name]/page.tsx),
+ * and it also stops a deploy triggered by a package merge from building
+ * against a CDN-stale copy of the index.
+ *
+ * The checkout is not traced into the serverless output - it is over 100 MB of
+ * archives - so at request time this directory is absent and every read below
+ * falls back to the network on its own.
+ */
+const localPackagesDir = path.join(process.cwd(), '..', 'packages')
+
+/** Whether this process can see the repository checkout. Build time: yes. */
+export const readsFromCheckout = existsSync(localPackagesDir)
 
 export async function fetchRepositoryPackages(): Promise<UploadedPackageMetadata[]> {
-  if (isDev) {
-    const jsonData = await fs.readFile(localRepoPath('packages', 'mpkg.packages.json'), 'utf8')
-    return JSON.parse(jsonData).packages
+  if (readsFromCheckout) {
+    try {
+      const jsonData = await fs.readFile(
+        path.join(localPackagesDir, 'mpkg.packages.json'),
+        'utf8'
+      )
+      return JSON.parse(jsonData).packages
+    } catch {
+      // A checkout without a generated index still gets a working site.
+    }
   }
 
   const response = await fetch(INDEX_URL, { next: { revalidate: 600 } })
@@ -28,10 +48,18 @@ export async function fetchPackageBySlug(slug: string): Promise<UploadedPackageM
   return packages.find((pkg) => packageSlug(pkg.mpackage) === slug) ?? null
 }
 
-/** Download the .mpackage archive itself so its contents can be listed. */
+/** Read the .mpackage archive itself so its contents can be listed. */
 export async function fetchPackageArchive(filename: string): Promise<Buffer> {
-  if (isDev) {
-    return fs.readFile(localRepoPath('packages', filename))
+  if (readsFromCheckout) {
+    try {
+      // The index is repository-controlled, but packageDownloadUrl already
+      // treats this value as a flat filename (encodeURIComponent escapes any
+      // slash), so it must not address anything outside the directory here
+      // either.
+      return await fs.readFile(path.join(localPackagesDir, path.basename(filename)))
+    } catch {
+      // The index can name an archive a stale checkout does not have yet.
+    }
   }
 
   // Archives run to tens of megabytes, past the data cache entry limit, so most

--- a/upload-site/app/packages/[name]/page.tsx
+++ b/upload-site/app/packages/[name]/page.tsx
@@ -3,15 +3,46 @@ import Image from 'next/image'
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
 import type { Metadata } from 'next'
-import { fetchPackageBySlug } from '@/app/lib/packages'
+import {
+  fetchPackageBySlug,
+  fetchRepositoryPackages,
+  readsFromCheckout,
+} from '@/app/lib/packages'
 import { getArchiveBuffer } from '@/app/lib/packageArchive'
 import { parsePackageContents } from '@/app/lib/packageContents'
 import { PackageExplorer } from '@/app/components/PackageExplorer'
 import { InstallCommands } from '@/app/components/InstallCommands'
 import { DragToInstall } from '@/app/components/DragToInstall'
-import { formatDate, packageDownloadUrl, packageIconUrl } from '@/app/lib/urls'
+import { formatDate, packageDownloadUrl, packageIconUrl, packageSlug } from '@/app/lib/urls'
 
 type PageProps = { params: Promise<{ name: string }> }
+
+/**
+ * What a package contains changes only when a new version of it is merged, and
+ * a merge redeploys the site - so these pages are built once per deploy rather
+ * than inheriting the index fetch's ten-minute window, which had the first
+ * visitor of every window paying for a whole archive download and unpack.
+ */
+export const revalidate = 86400
+
+/**
+ * Prerendering a package page means unpacking its archive, which is only
+ * affordable with the archives on disk; over the network it would be a hundred
+ * megabytes of build-time downloads, so without the checkout the pages stay
+ * on-demand exactly as before. Either way dynamicParams keeps a slug that was
+ * not prerendered - one added to the index after this build - rendering live.
+ */
+export async function generateStaticParams() {
+  if (!readsFromCheckout) return []
+
+  const packages = await fetchRepositoryPackages()
+  const slugs = new Set(
+    packages.filter((pkg) => pkg.filename).map((pkg) => packageSlug(pkg.mpackage))
+  )
+  slugs.delete('')
+
+  return [...slugs].map((name) => ({ name }))
+}
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { name } = await params

--- a/upload-site/app/packages/page.tsx
+++ b/upload-site/app/packages/page.tsx
@@ -6,6 +6,9 @@ export const metadata = {
   description: 'Browse every package available for the Mudlet MUD client',
 }
 
+/** Same reasoning as the home page: the checkout read carries no window. */
+export const revalidate = 600
+
 export default async function PackagesPage() {
   const packages = await fetchRepositoryPackages()
 

--- a/upload-site/app/page.tsx
+++ b/upload-site/app/page.tsx
@@ -5,6 +5,12 @@ import { ProgressBar } from './components/ProgressBar'
 import { CopyableCommand } from './components/CopyableCommand'
 import { fetchRepositoryPackages } from './lib/packages'
 
+/**
+ * The index used to carry this window on its own fetch; read off the checkout
+ * there is no fetch to carry it, so the page says how fresh it wants to be.
+ */
+export const revalidate = 600
+
 /** The next round number to aim for, so the bar keeps meaning as the repo grows. */
 const nextMilestone = (count: number) => Math.max(50, Math.ceil((count + 1) / 50) * 50)
 


### PR DESCRIPTION
> **Stacked on #759.** Base is `feat/upload-site-redesign`; merge that first. GitHub will retarget this to `main` automatically once #759 lands.

Follow-up to the redesign: makes package pages static instead of unpacking an archive at request time.

### The blocker first

`generateStaticParams` alone changed nothing — the first build still came out `ƒ (Dynamic)` for every route. The cause is `getServerSession()` in `app/layout.tsx`: a root layout that reads cookies opts the **entire app** into dynamic rendering, so this site has never prerendered anything.

It was only seeding `SessionProvider`'s initial value. Nothing server-side needed it — `Auth` is a client component already on `useSession()`, `/upload` is client-rendered, and the API routes that gate on a session call `getServerSession()` themselves. So that's the first commit; the rest is inert without it.

This is visible in production today: `/` currently returns `Cache-Control: private, no-cache, no-store` with `x-vercel-cache: MISS`, so neither Vercel nor Cloudflare caches a byte.

### The change

`fetchRepositoryPackages` and `fetchPackageArchive` now prefer the repository checkout whenever it is present, not just in dev. The site deploys out of this repo, so `../packages` is there during the build.

Neither read is required: the checkout is not traced into the serverless output (100+ MB of archives), so at request time both fall back to the network exactly as before, and `generateStaticParams` returns nothing rather than pulling the repository over HTTP. `dynamicParams` still covers a slug added to the index after a build.

Also fixes the stale-index-on-deploy problem noted in the redesign: the build reads `mpkg.packages.json` from the checkout instead of `raw.githubusercontent`, so a deploy triggered by a package merge can no longer build against a CDN-stale copy of the index it just changed.

### Result

| | before | after |
|---|---|---|
| `/packages/[name]` | `ƒ` dynamic, 600s inherited | `●` SSG ×224, 1d stated |
| `/`, `/packages`, `/upload` | `ƒ` dynamic | `○` static |
| package page response | full archive download + parse | **8.6 ms** |

```
✓ Generating static pages using 14 workers (233/233) in 1451ms
```

Revalidate windows are now stated rather than inherited. `getArchiveBuffer` also skips its 96 MB in-memory cache when reading from the checkout — it buys nothing against a local read, and the caller there is the build unpacking every package in turn.

### Verified

- `next build` → 224 package pages as static HTML; spot-checked the output contains the parsed explorer (543 triggers, 1.5 MB unpacked for Achaean System).
- `next start` → package page 200 in 8.6 ms, unknown slug 404s, file API serves.
- `tsc --noEmit` and `eslint` clean.

### One deploy setting to confirm

Prerendering needs the build to see `../packages`, which relies on Vercel's *"Include files outside the Root Directory in the Build Step"* (on by default). If it is off, `readsFromCheckout` is false and everything falls back to the current behaviour — no breakage, but no benefit either.