### PR TITLE
Play package sounds in the explorer

### DIFF
--- a/upload-site/app/components/PackageExplorer.tsx
+++ b/upload-site/app/components/PackageExplorer.tsx
@@ -399,6 +399,54 @@ const EntityViewer = ({ entity, scriptUrl }: { entity: PackageEntity; scriptUrl?
   )
 }
 
+/**
+ * A package that plays sounds is one you want to hear before installing, so
+ * they play in place rather than only downloading. Not everything a package
+ * ships can be decoded by a browser - the older sound packs carry ADPCM .wav -
+ * and the file route turns down anything over its preview cap, so a failed
+ * load falls back to the same download line the binary case offers. Mounted
+ * under a key of the url, so selecting another sound starts from scratch.
+ */
+const AudioPreview = ({ url }: { url: string }) => {
+  const [failed, setFailed] = useState(false)
+
+  if (failed) {
+    return (
+      <div className="p-4 text-sm text-muted">
+        <p>This sound could not be played here.</p>
+        <a href={url} className="mt-2 inline-block text-accent hover:text-accent-hover">
+          Download it instead →
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-6 bg-surface-muted p-6">
+      <svg
+        className="h-16 w-16 text-icon-audio opacity-40"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M11 5 6.5 9H3v6h3.5L11 19z" />
+        <path d="M15 9.5a3.5 3.5 0 0 1 0 5M17.8 6.5a7.5 7.5 0 0 1 0 11" />
+      </svg>
+      <audio
+        controls
+        preload="metadata"
+        src={url}
+        onError={() => setFailed(true)}
+        className="w-full max-w-sm"
+      />
+    </div>
+  )
+}
+
 const FileViewer = ({ file, url }: { file: PackageFileEntry; url: string }) => {
   const kind = previewKind(file.path)
   const [text, setText] = useState<string | null>(null)
@@ -455,6 +503,8 @@ const FileViewer = ({ file, url }: { file: PackageFileEntry; url: string }) => {
           />
         </div>
       )}
+
+      {kind === 'audio' && <AudioPreview key={url} url={url} />}
 
       {kind === 'text' &&
         (error ? (

--- a/upload-site/app/components/icons.tsx
+++ b/upload-site/app/components/icons.tsx
@@ -96,6 +96,13 @@ const IMAGE_ICON = (
   </>
 )
 
+const AUDIO_ICON = (
+  <>
+    <path d="M11 5 6.5 9H3v6h3.5L11 19z" />
+    <path d="M15 9.5a3.5 3.5 0 0 1 0 5M17.8 6.5a7.5 7.5 0 0 1 0 11" />
+  </>
+)
+
 const CODE_ICON = (
   <>
     <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
@@ -122,6 +129,7 @@ export const FileIcon = ({ path }: { path: string }) => {
   const kind = previewKind(path)
 
   if (kind === 'image') return <Svg className="text-icon-image">{IMAGE_ICON}</Svg>
+  if (kind === 'audio') return <Svg className="text-icon-audio">{AUDIO_ICON}</Svg>
   if (kind === 'binary') return <Svg className="text-icon-file">{BINARY_ICON}</Svg>
 
   const extension = fileExtension(path)

--- a/upload-site/app/globals.css
+++ b/upload-site/app/globals.css
@@ -37,6 +37,7 @@
     --icon-button: 219 39 119;
     --icon-folder: 202 138 4;
     --icon-image: 5 150 105;
+    --icon-audio: 202 84 15;
     --icon-file: 100 116 139;
 
     /* Syntax highlighting (highlight.js token classes, see .hljs-view below). */
@@ -74,6 +75,7 @@
     --icon-button: 244 114 182;
     --icon-folder: 250 204 21;
     --icon-image: 52 211 153;
+    --icon-audio: 251 146 60;
     --icon-file: 148 163 184;
 
     --syn-keyword: #d2a8ff;

--- a/upload-site/app/lib/fileTypes.ts
+++ b/upload-site/app/lib/fileTypes.ts
@@ -1,4 +1,4 @@
-export type PreviewKind = 'image' | 'text' | 'binary'
+export type PreviewKind = 'image' | 'audio' | 'text' | 'binary'
 
 const IMAGE_TYPES: Record<string, string> = {
   png: 'image/png',
@@ -9,6 +9,24 @@ const IMAGE_TYPES: Record<string, string> = {
   bmp: 'image/bmp',
   ico: 'image/x-icon',
   svg: 'image/svg+xml',
+}
+
+/**
+ * Sound packs are common - 117 .wav and 7 .mp3 files across the repository as
+ * it stands - and a package that plays sounds is one you want to hear before
+ * installing. Only formats a browser can actually decode are listed; anything
+ * else stays a download, and the player falls back to one anyway when the
+ * decode fails (old MUD packs carry ADPCM .wav files that Chrome turns down).
+ */
+const AUDIO_TYPES: Record<string, string> = {
+  wav: 'audio/wav',
+  mp3: 'audio/mpeg',
+  ogg: 'audio/ogg',
+  oga: 'audio/ogg',
+  opus: 'audio/ogg',
+  flac: 'audio/flac',
+  m4a: 'audio/mp4',
+  aac: 'audio/aac',
 }
 
 /** Extension -> highlight.js language id. Anything unlisted renders unhighlighted. */
@@ -41,6 +59,7 @@ export const fileExtension = (path: string) =>
 export function previewKind(path: string): PreviewKind {
   const extension = fileExtension(path)
   if (IMAGE_TYPES[extension]) return 'image'
+  if (AUDIO_TYPES[extension]) return 'audio'
   if (TEXT_LANGUAGES[extension]) return 'text'
   return 'binary'
 }
@@ -52,6 +71,7 @@ export function languageForFile(path: string): string {
 export function contentTypeForFile(path: string): string {
   const extension = fileExtension(path)
   if (IMAGE_TYPES[extension]) return IMAGE_TYPES[extension]
+  if (AUDIO_TYPES[extension]) return AUDIO_TYPES[extension]
   if (TEXT_LANGUAGES[extension]) return 'text/plain; charset=utf-8'
   return 'application/octet-stream'
 }

--- a/upload-site/tailwind.config.ts
+++ b/upload-site/tailwind.config.ts
@@ -35,6 +35,7 @@ export default {
           button: token('icon-button'),
           folder: token('icon-folder'),
           image: token('icon-image'),
+          audio: token('icon-audio'),
           file: token('icon-file'),
         },
         success: token("success"),


### PR DESCRIPTION
> **Stacked on #760**, which is stacked on #759. Merge order: #759 → #760 → this. Each retargets automatically as the one below it lands.

Sound packs are ordinary in this repository — I scanned all 224 archives:

```
wav: 117    mp3: 7
cleftofdimensions.mpackage alone ships ~100 .WAV files
```

But a sound was a `binary` file with no preview, so the only way to hear one was to install the package or download the archive.

### The change

`previewKind` gains an `audio` kind and the file viewer answers it with a player. Only formats a browser can actually decode are listed, so a `.mid` stays a download rather than becoming a player that never starts, and the file route serves them with a real `audio/*` content type instead of `application/octet-stream`.

Decoding can still fail on something listed — the older packs carry ADPCM `.wav` that Chrome turns down, and the route caps a preview at 8 MB — so the player falls back to the same download line the binary case offers. It is mounted under a `key` of the file url, so picking another sound after one fails starts clean rather than staying on the fallback.

Audio files get their own tree glyph and colour token alongside the existing image/code/text ones.

### Verified in a browser, not just built

Driven through Chrome against `next start`:

- **WAV** (`COD_BEAM.WAV`, 16-bit PCM mono 22050 Hz) — `readyState: 4`, `duration: 2.66`, `error: null`; called `play()` and `currentTime` advanced to `0.87` with `paused: false`. Actually plays, not just renders.
- **MP3** (`ascension.mp3`) — `readyState: 4`, `duration: 9.01`.
- **Failure path** — dispatched an `error` event, fallback message rendered.
- **Recovery** — selected another sound afterwards, player came back (`recoveredFromFallback: true`), fallback text gone. That is what the `key` is for.
- Both light and dark themes.
- `tsc --noEmit` and `eslint` clean; `next build` unaffected.