### PR TITLE
Guard the package index against a shape it cannot use

### DIFF
--- a/upload-site/app/lib/packages.ts
+++ b/upload-site/app/lib/packages.ts
@@ -29,7 +29,13 @@ export async function fetchRepositoryPackages(): Promise<UploadedPackageMetadata
         path.join(localPackagesDir, 'mpkg.packages.json'),
         'utf8'
       )
-      return JSON.parse(jsonData).packages
+      const { packages } = JSON.parse(jsonData)
+      // An index that parses but is not shaped like one is a reason to go and
+      // ask for the published copy, not a reason to build a site with no
+      // packages in it. Every caller treats this as an array, so a bare
+      // `.packages` here would hand them undefined and surface as a TypeError
+      // somewhere far less obvious - generateStaticParams, say.
+      if (Array.isArray(packages)) return packages
     } catch {
       // A checkout without a generated index still gets a working site.
     }
@@ -39,8 +45,11 @@ export async function fetchRepositoryPackages(): Promise<UploadedPackageMetadata
   if (!response.ok) {
     throw new Error(`Could not load the package index (HTTP ${response.status})`)
   }
-  const data = await response.json()
-  return data.packages
+  const { packages } = await response.json()
+  if (!Array.isArray(packages)) {
+    throw new Error('The package index carries no packages array')
+  }
+  return packages
 }
 
 export async function fetchPackageBySlug(slug: string): Promise<UploadedPackageMetadata | null> {

--- a/upload-site/app/lib/packages.ts
+++ b/upload-site/app/lib/packages.ts
@@ -45,11 +45,14 @@ export async function fetchRepositoryPackages(): Promise<UploadedPackageMetadata
   if (!response.ok) {
     throw new Error(`Could not load the package index (HTTP ${response.status})`)
   }
-  const { packages } = await response.json()
-  if (!Array.isArray(packages)) {
+  // Read through rather than destructured: a body of literal `null` parses
+  // fine and would throw on the destructure, ahead of the check meant to
+  // describe exactly that.
+  const data = await response.json()
+  if (!Array.isArray(data?.packages)) {
     throw new Error('The package index carries no packages array')
   }
-  return packages
+  return data.packages
 }
 
 export async function fetchPackageBySlug(slug: string): Promise<UploadedPackageMetadata | null> {

--- a/upload-site/next-sitemap.config.js
+++ b/upload-site/next-sitemap.config.js
@@ -29,7 +29,11 @@ function getPathsFromDir(dir) {
 function readPackageIndex() {
   try {
     const indexPath = path.join(process.cwd(), '..', 'packages', 'mpkg.packages.json')
-    return JSON.parse(fs.readFileSync(indexPath, 'utf8')).packages
+    const { packages } = JSON.parse(fs.readFileSync(indexPath, 'utf8'))
+    // An index that parses but carries no array is as unusable as one that
+    // does not parse, and the callers below map over this - returning
+    // `.packages` bare would throw past the try rather than fall back to it.
+    return Array.isArray(packages) ? packages : []
   } catch {
     return []
   }


### PR DESCRIPTION
Follow-up to #760 and #762, both merged before this landed. Greptile raised one half of it on #762; the other half is the same bug in `app/lib/packages.ts`, where it is more serious.

### The bug

Both readers pulled `.packages` straight off the parsed index. An index that is valid JSON but not shaped like an index — `{}`, a null, an object — yields `undefined` rather than an array, and every caller maps or filters over the result.

In `next-sitemap.config.js` the previous `getPackagePaths` did its mapping *inside* the `try`, so the `catch` covered this. Splitting reading from mapping is what let it escape the guarantee the comment still claimed:

```
❌ [next-sitemap] TypeError: Cannot read properties of undefined (reading 'map')
   at Object.additionalPaths
```

In `app/lib/packages.ts` it is worse. The shape predates #760, but it only ran under `isDev`, so a broken index cost a developer a confusing stack trace. Reading the checkout during the production build promoted it to something that **fails the deploy**, and it surfaces far from its cause — in `generateStaticParams`.

### Verified against `main` as it stands

Replacing `packages/mpkg.packages.json` with `{}` and building:

```
A: main's code       exit=1   TypeError: Cannot read properties of undefined (reading 'filter')
B: with these fixes  exit=0   224 package pages prerendered, sitemap Generation completed
```

### The fix

An index that parses but is not shaped like one is now treated the same as one that will not parse at all.

- `fetchRepositoryPackages` falls through to the published copy instead of returning `undefined` — a malformed *local* index is a reason to go and ask GitHub, not a reason to build a site with no packages in it. The network branch validates too, and says so plainly rather than handing `undefined` onwards.
- `readPackageIndex` returns `[]`, restoring the "must not fail a build" guarantee its own comment promises.

Two files, +17/−4. `tsc --noEmit` and `eslint` clean; a normal build is unchanged (233 pages, byte-identical sitemap).