### PR TITLE
Build the package site in CI, so a broken build stops being invisible

### DIFF
--- a/.github/workflows/build-package-site.yml
+++ b/.github/workflows/build-package-site.yml
@@ -1,0 +1,60 @@
+name: Build package site
+
+# The site is built and served by Vercel, where a failed build is silent: Vercel keeps
+# serving the last good deployment and nothing here says otherwise. That is how
+# packages.mudlet.org spent a year on an August 2025 build (#766). Building it here too
+# means a break fails on the pull request that caused it, where someone will see it.
+#
+# Deliberately needs no secrets - the build reads packages/mpkg.packages.json out of the
+# checkout rather than the network, so a bare clone is enough.
+
+on:
+  pull_request:
+    paths:
+      - 'upload-site/**'
+      - 'packages/mpkg.packages.json'
+      - '.github/workflows/build-package-site.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'upload-site/**'
+      - 'packages/mpkg.packages.json'
+      - '.github/workflows/build-package-site.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: build-package-site-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: npm
+        cache-dependency-path: upload-site/package-lock.json
+
+    # npm ci, not npm install: it installs exactly what the lockfile pins and refuses a
+    # lockfile that has drifted from package.json. Vercel installs the same way, so a
+    # lockfile it would choke on - a stale integrity hash, say - is caught here first.
+    - name: Install dependencies
+      working-directory: upload-site
+      run: npm ci
+
+    - name: Lint
+      working-directory: upload-site
+      run: npm run lint
+
+    # Prerenders a page per package from the index in the checkout, so this also covers
+    # an index the site cannot read - the failure #764 fixed. The commits that rewrite
+    # that index are automated ones pushed straight to main, which is why the push
+    # trigger above watches it as well.
+    - name: Build
+      working-directory: upload-site
+      run: npm run build

--- a/.github/workflows/build-package-site.yml
+++ b/.github/workflows/build-package-site.yml
@@ -31,6 +31,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # Nothing in this job writes: no commit, no comment, no deployment. A read-only token
+    # is all it needs, and it caps what a compromised action in the tree could reach.
+    permissions:
+      contents: read
+
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Closes #766.

`packages.mudlet.org` has been serving a build from 19 August 2025 - 405 commits behind `main`, the whole redesign in #759-#764 included. It went unnoticed because a failed Vercel build is silent: Vercel keeps serving the last good deployment, and nothing in this repo has an opinion about it.

Nothing here builds `upload-site`. `validate-mpackage.yml` covers package files; the site has no equivalent, and the only place its build ever ran was the one place where a failure is invisible.

### The change

One workflow, `.github/workflows/build-package-site.yml`: `npm ci`, `npm run lint`, `npm run build` in `upload-site`.

It needs no secrets. The build reads `packages/mpkg.packages.json` out of the checkout rather than the network, so a bare clone is enough - verified on a clean export of `main` with no `node_modules` and no `.env.local`:

```
$ git archive HEAD | tar -x -C /tmp/clean && cd /tmp/clean/upload-site
$ npm ci && npm run lint && npm run build
✓ Generating static pages using 14 workers (233/233) in 2.0s
✅ [next-sitemap] Generation completed
exit 0
```

`npm ci` rather than `npm install` is the point of the install step: it installs exactly what the lockfile pins and refuses a lockfile that has drifted. The four production builds that failed between March and April all died on `npm error code EINTEGRITY` - a stale integrity hash for `cookie@1.0.0`. On a pull request that is a red X on the commit that introduced it, four months earlier.

### Triggers

Pull requests, and pushes to `main`, that touch `upload-site/**`, `packages/mpkg.packages.json`, or the workflow itself.

The index is in that list deliberately. `app/lib/packages.ts` prerenders a page per package by reading it from the checkout, so an index the site cannot parse fails the build - the failure #764 fixed. Those commits are automated and land straight on `main`, so the push trigger is the only thing that would ever catch them. Package `.mpackage` files are not in the list: they do not change what the site prerenders until the index is regenerated after merge, so watching them would add a build to every package upload PR for nothing.

### What this does not do

Production is still on the August 2025 build. `main` builds clean today, so promoting it is just a deploy - but it ships a year of accumulated change in one go, so that is a call to make deliberately rather than fold in here.


