### PR TITLE
Sync core packages without a personal access token

### DIFF
--- a/.github/workflows/auto-merge-packages.yml
+++ b/.github/workflows/auto-merge-packages.yml
@@ -39,6 +39,7 @@ jobs:
       pull-requests: write
       checks: read
       actions: write # to ask for the index refresh after a merge
+      issues: write # to report an index refresh that could not be requested
 
     steps:
       - name: Evaluate gate and merge
@@ -204,18 +205,31 @@ jobs:
                 });
                 core.notice(`auto-merge: merged PR #${prNumber}`);
 
-                // The merge above is a GITHUB_TOKEN push, and GitHub does not fire
-                // triggers for those, so "Refresh json index" never saw it and the
-                // published listing kept the previous version - mpkg then never offered
-                // the update (#752). workflow_dispatch always creates a run, token or
-                // not, so ask for the refresh explicitly.
-                try {
-                  await github.rest.actions.createWorkflowDispatch({
-                    owner, repo, workflow_id: 'create-package-index.yml', ref: 'main',
+                // The merge is a GITHUB_TOKEN push, so it cannot fire the index
+                // workflow's own push trigger; workflow_dispatch is exempt (#752).
+                let refreshRequested = false;
+                for (let attempt = 1; attempt <= 3 && !refreshRequested; attempt++) {
+                  try {
+                    await github.rest.actions.createWorkflowDispatch({
+                      owner, repo, workflow_id: 'create-package-index.yml', ref: 'main',
+                    });
+                    refreshRequested = true;
+                    core.info('Requested a package index refresh.');
+                  } catch (e) {
+                    core.warning(`Could not request the index refresh (attempt ${attempt}): ${e.message}`);
+                    await new Promise(resolve => setTimeout(resolve, attempt * 5000));
+                  }
+                }
+                if (!refreshRequested) {
+                  // the PR is merged, so no later event re-runs this gate: without a
+                  // refresh the listing keeps the previous version and only says so here
+                  await github.rest.issues.create({
+                    owner, repo,
+                    title: 'Package index refresh could not be requested',
+                    body: `Merging #${prNumber} did not manage to request an index refresh, so `
+                      + `\`packages/mpkg.packages.json\` may still advertise the previous version. `
+                      + `Run "Refresh json index" by hand to publish it.`,
                   });
-                  core.info('Requested a package index refresh.');
-                } catch (e) {
-                  core.warning(`Could not request the index refresh: ${e.message}`);
                 }
               } catch (e) {
                 // Branch protection, a moved head (409), or merge conflicts land here.

--- a/.github/workflows/auto-merge-packages.yml
+++ b/.github/workflows/auto-merge-packages.yml
@@ -38,6 +38,7 @@ jobs:
       contents: write
       pull-requests: write
       checks: read
+      actions: write # to ask for the index refresh after a merge
 
     steps:
       - name: Evaluate gate and merge
@@ -202,6 +203,20 @@ jobs:
                   commit_title: `${pr.title} (#${prNumber})`,
                 });
                 core.notice(`auto-merge: merged PR #${prNumber}`);
+
+                // The merge above is a GITHUB_TOKEN push, and GitHub does not fire
+                // triggers for those, so "Refresh json index" never saw it and the
+                // published listing kept the previous version - mpkg then never offered
+                // the update (#752). workflow_dispatch always creates a run, token or
+                // not, so ask for the refresh explicitly.
+                try {
+                  await github.rest.actions.createWorkflowDispatch({
+                    owner, repo, workflow_id: 'create-package-index.yml', ref: 'main',
+                  });
+                  core.info('Requested a package index refresh.');
+                } catch (e) {
+                  core.warning(`Could not request the index refresh: ${e.message}`);
+                }
               } catch (e) {
                 // Branch protection, a moved head (409), or merge conflicts land here.
                 // Leave the PR for a maintainer rather than failing the run.

--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -7,6 +7,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:    
 
+# Two runs indexing at once is last-writer-wins on a stale tree: each one regenerates the
+# index from the packages it checked out, and whichever pushes second wins with whatever
+# it saw. Queue them instead.
+concurrency:
+  group: package-index
+
 jobs:
   reindex-json-file:
     runs-on: ubuntu-latest
@@ -16,6 +22,7 @@ jobs:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository
       contents: write
+      issues: write
 
     steps:
     - uses: actions/checkout@v4
@@ -51,3 +58,20 @@ jobs:
       with:
         commit_message: Automated package index update.
         file_pattern: 'packages/*.packages.json packages/icons/*'
+
+    # The workflows that ask for a refresh cannot see how it went, and a run that fails
+    # here leaves mpkg offering whatever the listing said before.
+    - name: Report a refresh that failed
+      if: failure() || cancelled()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        title='Package index refresh is failing'
+        existing=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty') || existing=
+        if [ -n "$existing" ]; then
+          gh issue comment "$existing" --body "Failed again: ${RUN_URL}"
+        else
+          gh issue create --title "$title" \
+            --body "packages/mpkg.packages.json was not regenerated, so mpkg is still offering the versions it listed before. Re-running this workflow republishes it: ${RUN_URL}"
+        fi

--- a/.github/workflows/update-core-packages.yml
+++ b/.github/workflows/update-core-packages.yml
@@ -1,72 +1,93 @@
 name: Update core packages
 
+# Mudlet bundles a handful of packages that are also published here, and they are edited
+# in Mudlet's repository rather than this one. This brings the copies mpkg serves in line
+# with what Mudlet's development branch ships.
+#
+# It commits to main instead of opening a pull request. The PR version needed a personal
+# access token, because a PR opened with GITHUB_TOKEN does not run the validation and
+# auto-merge workflows it depends on; that token stopped being accepted in July 2025 and
+# every weekly run since then died at the push, unnoticed, leaving mpkg serving packages
+# over a year old. There is nothing to review in these syncs anyway: each archive comes
+# from Mudlet's development branch, where check-mpackages has already confirmed it matches
+# its sources. Nothing here holds a credential.
+
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * fri'
 
+permissions:
+  contents: write # commit the refreshed archives to main
+  actions: write # ask for the index refresh (see "Refresh the package index")
+  issues: write # so a broken sync is visible without opening the Actions tab
+
 jobs:
   update:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'Mudlet' }}
-    strategy:
-      matrix:
-        package:
-          - name: deleteOldProfiles
-            description: "Delete Old Profiles package"
-            path: src/packages/deleteOldProfiles/deleteOldProfiles.mpackage
-          - name: echo
-            description: "Echo package"
-            path: src/packages/echo/echo.mpackage
-          - name: enable-accessibility
-            description: "Enable Accessibility package"
-            path: src/packages/enable-accessibility/enable-accessibility.mpackage
-          - name: run-lua-code
-            description: "Run Lua Code package"
-            path: src/packages/run-lua-code/run-lua-code.mpackage
-          - name: generic_mapper
-            description: "Generic Mapper package"
-            path: src/packages/generic_mapper/generic_mapper.mpackage
-          - name: mudlet-base-ui
-            description: "Mudlet base UI package"
-            path: src/packages/mudlet-base-ui/mudlet-base-ui.mpackage
-          # - name: gui-drop
-          #   description: "GUI Drop package"
-          #   path: src/packages/gui-drop/gui-drop.mpackage
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - name: Download ${{ matrix.package.name }} package
-        uses: carlosperate/download-file-action@v2.0.2
-        with:
-          file-url: https://raw.githubusercontent.com/Mudlet/Mudlet/development/${{ matrix.package.path }}
-          file-name: ${{ matrix.package.name }}.mpackage
-          location: packages/
-
-      - name: Check for changes in ${{ matrix.package.name }}
-        id: check-changes
+      - name: Fetch the packages Mudlet bundles
+        env:
+          # gui-drop is bundled by Mudlet as well, but is not published through mpkg
+          PACKAGES: deleteOldProfiles echo enable-accessibility run-lua-code generic_mapper mudlet-base-ui
         run: |
-          echo "Checking for changes in packages/${{ matrix.package.name }}.mpackage..."
-          if git diff --quiet "packages/${{ matrix.package.name }}.mpackage"; then
-            echo "No changes detected in ${{ matrix.package.name }}"
-          else
-            echo "Changes detected in ${{ matrix.package.name }}"
-            echo "changes=true" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          for package in $PACKAGES; do
+            curl -fsSL --retry 3 \
+              "https://raw.githubusercontent.com/Mudlet/Mudlet/development/src/packages/${package}/${package}.mpackage" \
+              -o "packages/${package}.mpackage"
+          done
+
+      - name: Commit the ones that changed
+        id: sync
+        run: |
+          set -euo pipefail
+          # --porcelain rather than diff, so a package added to the list above counts
+          # as a change on its first run, when it is still untracked
+          if [ -z "$(git status --porcelain -- packages)" ]; then
+            echo "Every core package already matches development."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-      - name: Create Pull Request for ${{ matrix.package.name }}
-        uses: peter-evans/create-pull-request@v7
-        if: steps.check-changes.outputs.changes == 'true'
-        with:
-          token: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
-          add-paths: packages/${{ matrix.package.name }}.mpackage
-          branch: update-${{ matrix.package.name }}-package
-          commit-message: "(autocommit) Updated ${{ matrix.package.description }} to latest version"
-          title: "Infrastructure: update ${{ matrix.package.description }} to latest version"
-          body: |
-            #### Brief overview of PR changes/additions
-            🔄 An automated PR to update the ${{ matrix.package.description }} to its latest version.
+          git status --porcelain -- packages
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A packages
+          git commit -qm "Update the packages Mudlet bundles to what development ships"
+          # a package upload may have landed while we were downloading
+          git pull --rebase --quiet origin main
+          git push origin HEAD:main
+          echo "changed=true" >> "$GITHUB_OUTPUT"
 
-            #### Other info
-            _update triggered by ${{ github.ref }} ${{ github.sha }}_
-          author: mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>
+      - name: Refresh the package index
+        if: steps.sync.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # GitHub suppresses the triggers a GITHUB_TOKEN push would normally fire, to
+          # avoid workflows setting each other off forever, so the index workflow's own
+          # "push to main" trigger will not see the commit above. Asking for it by hand
+          # does work: workflow_dispatch is one of the two events that always runs.
+          # Without this mpkg keeps advertising the versions it served before.
+          gh workflow run create-package-index.yml --ref main
+
+      - name: Report a sync that failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # A weekly job that fails quietly is one nobody notices for a year.
+          title='Core package sync is failing'
+          existing=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Failed again: ${RUN_URL}"
+          else
+            gh issue create --title "$title" \
+              --body "The weekly sync of the packages Mudlet bundles failed, so mpkg is serving whatever it served before: ${RUN_URL}"
+          fi

--- a/.github/workflows/update-core-packages.yml
+++ b/.github/workflows/update-core-packages.yml
@@ -1,16 +1,14 @@
 name: Update core packages
 
-# Mudlet bundles a handful of packages that are also published here, and they are edited
-# in Mudlet's repository rather than this one. This brings the copies mpkg serves in line
-# with what Mudlet's development branch ships.
+# Mudlet bundles a handful of the packages published here, and they are edited in Mudlet's
+# repository rather than this one. This brings the copies mpkg serves in line with what
+# Mudlet's development branch ships.
 #
-# It commits to main instead of opening a pull request. The PR version needed a personal
-# access token, because a PR opened with GITHUB_TOKEN does not run the validation and
-# auto-merge workflows it depends on; that token stopped being accepted in July 2025 and
-# every weekly run since then died at the push, unnoticed, leaving mpkg serving packages
-# over a year old. There is nothing to review in these syncs anyway: each archive comes
-# from Mudlet's development branch, where check-mpackages has already confirmed it matches
-# its sources. Nothing here holds a credential.
+# It commits to main rather than opening a pull request, which would need a personal access
+# token: a PR opened with GITHUB_TOKEN does not run the validation and auto-merge workflows
+# such a PR would depend on. Nothing is lost by skipping them - every archive comes from
+# Mudlet's development branch, where check-mpackages has already confirmed it matches its
+# sources.
 
 on:
   workflow_dispatch:
@@ -18,9 +16,9 @@ on:
     - cron: '0 0 * * fri'
 
 permissions:
-  contents: write # commit the refreshed archives to main
-  actions: write # ask for the index refresh (see "Refresh the package index")
-  issues: write # so a broken sync is visible without opening the Actions tab
+  contents: write
+  actions: write # for gh workflow run
+  issues: write
 
 jobs:
   update:
@@ -31,23 +29,37 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Fetch the packages Mudlet bundles
+        id: fetch
         env:
-          # gui-drop is bundled by Mudlet as well, but is not published through mpkg
           PACKAGES: deleteOldProfiles echo enable-accessibility run-lua-code generic_mapper mudlet-base-ui
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          unfetched=
           for package in $PACKAGES; do
-            curl -fsSL --retry 3 \
-              "https://raw.githubusercontent.com/Mudlet/Mudlet/development/src/packages/${package}/${package}.mpackage" \
-              -o "packages/${package}.mpackage"
+            archive="packages/${package}.mpackage"
+            # download beside the published copy rather than onto it: curl opens its
+            # output file before it knows the response. Reading config.lua back out
+            # rejects anything that is not the archive we asked for - nothing else
+            # inspects these before they reach main
+            if curl -fsSL --retry 3 \
+                 "https://raw.githubusercontent.com/Mudlet/Mudlet/development/src/packages/${package}/${package}.mpackage" \
+                 -o "${archive}.new" \
+               && unzip -p "${archive}.new" config.lua > /dev/null 2>&1; then
+              mv "${archive}.new" "${archive}"
+            else
+              # one package moving upstream must not hold back the others
+              unfetched="${unfetched} ${package}"
+              rm -f "${archive}.new"
+            fi
           done
+          echo "unfetched=${unfetched# }" >> "$GITHUB_OUTPUT"
 
       - name: Commit the ones that changed
         id: sync
         run: |
           set -euo pipefail
-          # --porcelain rather than diff, so a package added to the list above counts
-          # as a change on its first run, when it is still untracked
+          # --porcelain rather than diff, so a package added to the list above counts as
+          # a change on its first run, while it is still untracked
           if [ -z "$(git status --porcelain -- packages)" ]; then
             echo "Every core package already matches development."
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -65,29 +77,36 @@ jobs:
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Refresh the package index
-        if: steps.sync.outputs.changed == 'true'
+        # also on a manual run with nothing to commit: that is the repair when an earlier
+        # run pushed packages but the refresh did not happen
+        if: steps.sync.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # GitHub suppresses the triggers a GITHUB_TOKEN push would normally fire, to
-          # avoid workflows setting each other off forever, so the index workflow's own
-          # "push to main" trigger will not see the commit above. Asking for it by hand
-          # does work: workflow_dispatch is one of the two events that always runs.
-          # Without this mpkg keeps advertising the versions it served before.
+          # The push above cannot fire the index workflow's own push trigger: GitHub does
+          # not run workflows for events a GITHUB_TOKEN action causes, except dispatches.
           gh workflow run create-package-index.yml --ref main
 
+      - name: Fail if a package could not be fetched
+        if: steps.fetch.outputs.unfetched != ''
+        env:
+          UNFETCHED: ${{ steps.fetch.outputs.unfetched }}
+        run: |
+          echo "::error::could not fetch: ${UNFETCHED} - moved in Mudlet's repository?"
+          exit 1
+
       - name: Report a sync that failed
-        if: failure()
+        if: failure() || cancelled()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          # A weekly job that fails quietly is one nobody notices for a year.
           title='Core package sync is failing'
-          existing=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+          # a failed search must not cost us the report as well
+          existing=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty') || existing=
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "Failed again: ${RUN_URL}"
           else
             gh issue create --title "$title" \
-              --body "The weekly sync of the packages Mudlet bundles failed, so mpkg is serving whatever it served before: ${RUN_URL}"
+              --body "The weekly sync of the packages Mudlet bundles did not finish, so mpkg may be serving older copies than Mudlet ships: ${RUN_URL}"
           fi


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Takes the expiring credential out of this repo's automation, and fixes #752 in the same stroke - both are the same GitHub rule: *events triggered by the `GITHUB_TOKEN` will not create a new workflow run, with the following exceptions: `workflow_dispatch` and `repository_dispatch` events always create workflow runs.*

- **update-core-packages.yml** commits the refreshed archives straight to main and asks for the index refresh with `gh workflow run`, instead of opening a PR through `GH_PAT_UPDATE_3RDPARTY`. One job with a loop rather than a six-way matrix, but each package is still fetched independently, and an archive only replaces the published copy once it has been checked to open. A failed run opens (or comments on) an issue.
- **auto-merge-packages.yml** requests the same refresh after it merges, retrying, and files an issue if it never lands - once the PR is merged nothing else will retry it.
- **create-package-index.yml** now queues its runs instead of racing them, and reports a refresh that failed. It fails 8 runs in 30 today, always at the push; those failures currently self-heal only because the next push re-triggers it, which a dispatched run cannot rely on.

#### Motivation
The PR-based sync needed a PAT because a PR opened with `GITHUB_TOKEN` does not run the validation and auto-merge workflows it depends on. That token has been rejected since 2025-07-11 - `git push` gets no credential and the job dies with `could not read Username`, exit 128 - and all 57 runs since have failed unnoticed. mpkg has been serving deleteOldProfiles 1 (dev has 3), echo 1 (2), enable-accessibility 2 (3), run-lua-code 5 (6), generic_mapper 2.1.9 (2.1.11) and mudlet-base-ui 1.0.0 (1.6.1).

Nothing is reviewed away by dropping the PR: these six come from Mudlet's development branch, where `check-mpackages` already verifies each archive matches its sources, and the sync PRs were auto-merged when they worked. `mudlet-base-ui` could never have merged itself anyway - the validator's security grep flags its `sysDataSendRequest` use (#755).

`GH_PAT_UPDATE_3RDPARTY` can be deleted from this repo once this lands.

Fixes #752

#### Other info
Tested by running the fetch, change-detection and commit steps against this repo in a scratch clone: a first run fetches all six and commits, a second detects no change, a name that 404s is isolated while the rest still publish, and a non-archive response is rejected without touching the published copy.

`gui-drop` is published here at version 1 while Mudlet ships 1.3, and was left out of the sync list without a recorded reason - not changed here, filed separately.

Assisted-by: Claude:claude-opus-5
