### PR TITLE
Stop long package names from widening the page on mobile

### DIFF
--- a/upload-site/app/components/IntroSection.tsx
+++ b/upload-site/app/components/IntroSection.tsx
@@ -3,7 +3,7 @@ import { CopyableCommand } from './CopyableCommand'
 
 export function IntroSection() {
   return (
-    <div className="grid gap-6 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
       <section className="card p-6">
         <h2 className="text-xl font-semibold">What is this?</h2>
         <p className="mt-3 text-sm leading-relaxed text-foreground/90">
@@ -40,7 +40,7 @@ export function IntroSection() {
           </a>
           !
         </p>
-        <ul className="mt-3 grid gap-1.5 text-sm text-foreground/90 sm:grid-cols-2">
+        <ul className="mt-3 grid grid-cols-1 gap-1.5 text-sm text-foreground/90 sm:grid-cols-2">
           <li className="flex gap-2">
             <span aria-hidden="true" className="text-accent">
               →

--- a/upload-site/app/components/PackageBrowser.tsx
+++ b/upload-site/app/components/PackageBrowser.tsx
@@ -103,7 +103,7 @@ export const PackageBrowser = ({ packages }: { packages: UploadedPackageMetadata
           </p>
         </div>
       ) : (
-        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {visible.map((pkg) => (
             <li key={pkg.filename ?? pkg.mpackage}>
               <PackageCard pkg={pkg} authorPackageCount={authorCounts.get(pkg.author ?? '') ?? 0} />

--- a/upload-site/app/components/PackageCard.tsx
+++ b/upload-site/app/components/PackageCard.tsx
@@ -31,7 +31,7 @@ export const PackageCard = ({ pkg, authorPackageCount = 0 }: PackageCardProps) =
           />
         )}
         <div className="min-w-0 flex-1">
-          <h3 className="truncate font-semibold text-foreground group-hover:text-accent">
+          <h3 className="line-clamp-2 break-words font-semibold text-foreground group-hover:text-accent">
             {pkg.mpackage}
           </h3>
           <p className="truncate text-sm text-muted">

--- a/upload-site/app/components/PackageExplorer.tsx
+++ b/upload-site/app/components/PackageExplorer.tsx
@@ -613,7 +613,7 @@ export const PackageExplorer = ({ contents, slug }: PackageExplorerProps) => {
     })
 
   return (
-    <div className="grid gap-4 lg:grid-cols-5">
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-5">
       <div className="card flex h-[32rem] flex-col overflow-hidden lg:col-span-2 lg:h-[36rem]">
         <div className="border-b border-border p-3">
           <input

--- a/upload-site/app/components/PackagePreview.tsx
+++ b/upload-site/app/components/PackagePreview.tsx
@@ -73,7 +73,7 @@ export function PackagePreview({
 
         <dl className="mt-6 space-y-3">
           {FIELDS.map(({ key, label }) => (
-            <div key={key} className="grid grid-cols-[7rem,1fr] items-baseline gap-3 text-sm">
+            <div key={key} className="grid grid-cols-[7rem_minmax(0,1fr)] items-baseline gap-3 text-sm">
               <dt className="flex items-center gap-1.5 font-medium text-muted">
                 {label} <Status field={key} />
               </dt>
@@ -83,7 +83,7 @@ export function PackagePreview({
             </div>
           ))}
 
-          <div className="grid grid-cols-[7rem,1fr] items-baseline gap-3 text-sm">
+          <div className="grid grid-cols-[7rem_minmax(0,1fr)] items-baseline gap-3 text-sm">
             <dt className="flex items-center gap-1.5 font-medium text-muted">
               Description <Status field="description" />
             </dt>

--- a/upload-site/app/packages/[name]/page.tsx
+++ b/upload-site/app/packages/[name]/page.tsx
@@ -112,7 +112,7 @@ export default async function PackagePage({ params }: PageProps) {
             />
           )}
           <div className="min-w-0">
-            <h1 className="text-3xl font-bold tracking-tight">{pkg.mpackage}</h1>
+            <h1 className="break-words text-3xl font-bold tracking-tight">{pkg.mpackage}</h1>
             {pkg.title && <p className="mt-1 text-muted">{pkg.title}</p>}
           </div>
         </div>
@@ -134,7 +134,7 @@ export default async function PackagePage({ params }: PageProps) {
         ))}
       </dl>
 
-      <div className="mt-6 grid gap-4 md:grid-cols-[minmax(0,1fr)_16rem] md:items-start">
+      <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-[minmax(0,1fr)_16rem] md:items-start">
         <InstallCommands
           packageName={pkg.mpackage ?? ''}
           downloadUrl={packageDownloadUrl(pkg.filename)}

--- a/upload-site/app/page.tsx
+++ b/upload-site/app/page.tsx
@@ -73,7 +73,7 @@ export default async function Home() {
             See all
           </Link>
         </div>
-        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {recent.map((pkg) => (
             <li key={pkg.filename ?? pkg.mpackage}>
               <PackageCard pkg={pkg} />


### PR DESCRIPTION
A package with a long name pushed the whole listing page wider than the phone viewport.


## What was wrong

The card grid was `grid gap-4 sm:grid-cols-2 lg:grid-cols-3` — it declares its columns only from `sm:` up. Below that breakpoint the single column comes from `grid-auto-columns: auto`, whose base size is the item's **min-content** width. Card titles are `truncate`, and the min-content of a `white-space: nowrap` run is the entire string, so one long name floored the track at the name's full width. Measured at a 375px viewport: `scrollWidth` 482, grid track 465.77px.

`min-w-0` on the title's wrapper doesn't save it — that removes the automatic minimum size, but it doesn't shrink the intrinsic min-content the track is sized from.

This also explains the separate report of the top bar being narrower than the cards. The header is a normal block sized to the viewport while the document scrolls wider; in-app browsers shrink-to-fit the whole document, so the header renders narrower than the content beneath it. It only shows up where that shrink-to-fit happens, which is why it didn't reproduce in a desktop browser.

## The fix

Tailwind's `grid-cols-N` expands to `repeat(N, minmax(0, 1fr))`, so every grid that named columns at a breakpoint was already safe *there* and only broke *below* it. Each one now gets an explicit `grid-cols-1` base:

- `PackageBrowser.tsx` (the listing grid — the reported bug)
- `page.tsx` (recent packages on the home page)
- `IntroSection.tsx` (two grids)
- `PackageExplorer.tsx`
- `packages/[name]/page.tsx`

`PackagePreview.tsx` had the same hazard in a hand-written track list, `grid-cols-[7rem,1fr]` → now `grid-cols-[7rem_minmax(0,1fr)]`.

Card titles change from `truncate` to `line-clamp-2 break-words`, so a long name reads in full over two lines rather than being cut to `AbandonedRealms - Gui Add-on - T…`. Short names render exactly as before. The detail page's `h1` gets `break-words` as insurance against an unbreakable name — no package currently has one.

## Testing

Checked at 360 / 375 / 390 / 768 / 1280px on the home, listing, package detail and upload pages: `scrollWidth === clientWidth` everywhere, and no element extends past the viewport edge. The only horizontal overflow left is inside the syntax-highlighted `<pre>`, which is its own scroll container by design.

`npm run lint` and `tsc --noEmit` are clean.

