### PR TITLE
Give every package author a page of their own

### DIFF
--- a/upload-site/app/authors/[slug]/page.tsx
+++ b/upload-site/app/authors/[slug]/page.tsx
@@ -1,0 +1,148 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
+import { PackageCard } from '@/app/components/PackageCard'
+import {
+  AuthorSummary,
+  authorHref,
+  authorSlug,
+  collectAuthors,
+  parseAuthorNames,
+} from '@/app/lib/authors'
+import { fetchRepositoryPackages } from '@/app/lib/packages'
+import { formatDate } from '@/app/lib/urls'
+
+type PageProps = { params: Promise<{ slug: string }> }
+
+/** Author pages change exactly when the index does, so they share its window. */
+export const revalidate = 600
+
+/**
+ * Non-ASCII names keep their own slug (see authorSlug), which reaches a route
+ * percent-encoded. Next decodes route params, but a slug that arrives encoded
+ * anyway should still find its author rather than 404.
+ */
+function decodeSlug(slug: string): string {
+  try {
+    return decodeURIComponent(slug)
+  } catch {
+    return slug
+  }
+}
+
+async function findAuthorBySlug(slug: string): Promise<AuthorSummary | null> {
+  const authors = collectAuthors(await fetchRepositoryPackages())
+  const wanted = decodeSlug(slug)
+  return authors.find((author) => author.slug === wanted) ?? null
+}
+
+/**
+ * Unlike package pages these cost nothing to build - no archive is unpacked -
+ * so they prerender whether or not the checkout is there to read.
+ */
+export async function generateStaticParams() {
+  const authors = collectAuthors(await fetchRepositoryPackages())
+  return authors.map((author) => ({ slug: author.slug }))
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const author = await findAuthorBySlug((await params).slug)
+  if (!author) return { title: 'Author not found' }
+
+  const count = author.packages.length
+  return {
+    title: author.name,
+    description: `${count} Mudlet ${count === 1 ? 'package' : 'packages'} by ${author.name}`,
+  }
+}
+
+const Tile = ({ value, label }: { value: string; label: string }) => (
+  <div className="card p-4">
+    <p className="text-2xl font-semibold tabular-nums">{value}</p>
+    <p className="mt-1 text-sm text-muted">{label}</p>
+  </div>
+)
+
+export default async function AuthorPage({ params }: PageProps) {
+  const { slug } = await params
+  const author = await findAuthorBySlug(slug)
+  if (!author) notFound()
+
+  const count = author.packages.length
+
+  // Anyone credited alongside them on a package, in as many packages as they
+  // share - the people behind "Akaya, mods by Zooka" and the like.
+  const collaborators = new Map<string, { name: string; slug: string; shared: number }>()
+  for (const pkg of author.packages) {
+    for (const name of parseAuthorNames(pkg.author)) {
+      const otherSlug = authorSlug(name)
+      if (!otherSlug || otherSlug === author.slug) continue
+      const existing = collaborators.get(otherSlug)
+      if (existing) existing.shared += 1
+      else collaborators.set(otherSlug, { name, slug: otherSlug, shared: 1 })
+    }
+  }
+  const sharedWith = [...collaborators.values()].sort(
+    (a, b) => b.shared - a.shared || a.name.localeCompare(b.name, 'en')
+  )
+
+  const oldest = author.packages.reduce(
+    (earliest, pkg) => (pkg.uploaded && pkg.uploaded < earliest ? pkg.uploaded : earliest),
+    author.latestUpload
+  )
+
+  return (
+    <main className="py-8">
+      <Link href="/authors" className="text-sm text-muted hover:text-foreground">
+        ← All authors
+      </Link>
+
+      <header className="mt-4">
+        <h1 className="break-words text-3xl font-bold tracking-tight">{author.name}</h1>
+        <p className="mt-1 text-muted">
+          {count} {count === 1 ? 'package' : 'packages'} in the repository
+          {author.aliases.length > 1 && (
+            <> · also credited as {author.aliases.slice(1).join(', ')}</>
+          )}
+        </p>
+      </header>
+
+      <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <Tile value={String(count)} label={count === 1 ? 'package' : 'packages'} />
+        <Tile value={formatDate(author.latestUpload) ?? '—'} label="last update" />
+        <Tile value={formatDate(oldest) ?? '—'} label="first published" />
+        <Tile value={String(sharedWith.length)} label="collaborators" />
+      </div>
+
+      {sharedWith.length > 0 && (
+        <section className="mt-8">
+          <h2 className="mb-3 text-lg font-semibold">Worked with</h2>
+          <ul className="flex flex-wrap gap-2">
+            {sharedWith.map((person) => (
+              <li key={person.slug}>
+                <Link
+                  href={authorHref(person.slug)}
+                  className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 text-sm transition-colors hover:bg-surface-muted"
+                >
+                  {person.name}
+                  <span className="text-xs tabular-nums text-muted">{person.shared}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section className="mt-8">
+        <h2 className="mb-3 text-lg font-semibold">Packages</h2>
+        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {author.packages.map((pkg) => (
+            <li key={pkg.filename ?? pkg.mpackage}>
+              <PackageCard pkg={pkg} />
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  )
+}

--- a/upload-site/app/authors/page.tsx
+++ b/upload-site/app/authors/page.tsx
@@ -1,0 +1,37 @@
+import { AuthorBrowser, AuthorListEntry } from '../components/AuthorBrowser'
+import { collectAuthors } from '../lib/authors'
+import { fetchRepositoryPackages } from '../lib/packages'
+
+export const metadata = {
+  title: 'Authors',
+  description: 'Everyone who has published a package for the Mudlet MUD client',
+}
+
+/** Same reasoning as the package listing: the checkout read carries no window. */
+export const revalidate = 600
+
+export default async function AuthorsPage() {
+  const packages = await fetchRepositoryPackages()
+
+  // Only what a card shows is handed to the client - the full package objects
+  // would be the whole index over again, once per author who appears in it.
+  const authors: AuthorListEntry[] = collectAuthors(packages).map((author) => ({
+    slug: author.slug,
+    name: author.name,
+    aliases: author.aliases,
+    packageCount: author.packages.length,
+    latestUpload: author.latestUpload,
+    sample: author.packages.slice(0, 4).map((pkg) => pkg.mpackage ?? '').filter(Boolean),
+  }))
+
+  return (
+    <main className="py-8">
+      <h1 className="mb-2 text-3xl font-bold tracking-tight">Authors</h1>
+      <p className="mb-8 max-w-3xl text-muted">
+        Everyone credited on a package in the repository. Open an author to see what they have
+        made, and who they made it with.
+      </p>
+      <AuthorBrowser authors={authors} />
+    </main>
+  )
+}

--- a/upload-site/app/components/AuthorBrowser.tsx
+++ b/upload-site/app/components/AuthorBrowser.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import Link from 'next/link'
+import { useDeferredValue, useMemo, useState } from 'react'
+import { authorHref } from '@/app/lib/authors'
+import { formatDate } from '@/app/lib/urls'
+
+/** What the index page needs about an author - not their packages in full. */
+export interface AuthorListEntry {
+  slug: string
+  name: string
+  /** Other spellings of the name, so a search for either finds them. */
+  aliases: string[]
+  packageCount: number
+  latestUpload: number
+  /** A few package names, as a hint of what this author works on. */
+  sample: string[]
+}
+
+const SORTS = {
+  packages: 'Most packages',
+  name: 'Name (A-Z)',
+  recent: 'Recently active',
+} as const
+
+type SortKey = keyof typeof SORTS
+
+export const AuthorBrowser = ({ authors }: { authors: AuthorListEntry[] }) => {
+  const [query, setQuery] = useState('')
+  const [sortBy, setSortBy] = useState<SortKey>('packages')
+  const deferredQuery = useDeferredValue(query)
+
+  const visible = useMemo(() => {
+    const needle = deferredQuery.trim().toLowerCase()
+    const filtered = needle
+      ? authors.filter((author) =>
+          [...author.aliases, ...author.sample].some((text) =>
+            text.toLowerCase().includes(needle)
+          )
+        )
+      : authors.slice()
+
+    return filtered.sort((a, b) => {
+      if (sortBy === 'name') return a.name.localeCompare(b.name, 'en', { sensitivity: 'base' })
+      if (sortBy === 'recent') return b.latestUpload - a.latestUpload
+      return b.packageCount - a.packageCount || a.name.localeCompare(b.name, 'en')
+    })
+  }, [authors, deferredQuery, sortBy])
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <svg
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            aria-hidden="true"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <path d="m20 20-3.5-3.5" />
+          </svg>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search by author or package name"
+            aria-label="Search authors"
+            className="w-full rounded-lg border border-border bg-surface py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted"
+          />
+        </div>
+
+        <label className="flex items-center gap-2 text-sm text-muted">
+          <span className="sr-only sm:not-sr-only">Sort</span>
+          <select
+            value={sortBy}
+            onChange={(event) => setSortBy(event.target.value as SortKey)}
+            className="rounded-lg border border-border bg-surface px-3 py-2 text-sm text-foreground"
+          >
+            {Object.entries(SORTS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <p className="mb-4 text-sm text-muted" aria-live="polite">
+        {visible.length} of {authors.length} authors
+      </p>
+
+      {visible.length === 0 ? (
+        <div className="card p-10 text-center">
+          <p className="font-medium">No authors match “{query.trim()}”.</p>
+          <p className="mt-1 text-sm text-muted">
+            Try a shorter search, or{' '}
+            <button
+              type="button"
+              onClick={() => setQuery('')}
+              className="text-accent hover:text-accent-hover"
+            >
+              clear the search
+            </button>
+            .
+          </p>
+        </div>
+      ) : (
+        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {visible.map((author) => (
+            <li key={author.slug}>
+              <Link
+                href={authorHref(author.slug)}
+                className="card-interactive group flex h-full flex-col gap-2 p-4"
+              >
+                <div className="flex items-baseline justify-between gap-3">
+                  <h2 className="min-w-0 break-words font-semibold text-foreground group-hover:text-accent">
+                    {author.name}
+                  </h2>
+                  <span className="shrink-0 rounded-full bg-surface-muted px-2 py-0.5 text-xs tabular-nums text-muted">
+                    {author.packageCount}
+                  </span>
+                </div>
+
+                <p className="line-clamp-2 text-sm text-muted">{author.sample.join(' · ')}</p>
+
+                {formatDate(author.latestUpload) && (
+                  <p className="mt-auto pt-1 text-xs text-muted">
+                    Last update {formatDate(author.latestUpload)}
+                  </p>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/upload-site/app/components/AuthorCredit.tsx
+++ b/upload-site/app/components/AuthorCredit.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+import { authorHref, authorSlug, parseAuthorNames } from '@/app/lib/authors'
+
+/**
+ * A package's author line, with every name in it linked to that author's page
+ * and the rest of the credit left exactly as written - so "Akaya, mods by
+ * Zooka" keeps saying that, while both names lead somewhere.
+ *
+ * The names come out of this very string, so each is found in it by scanning
+ * forwards; a name that cannot be located (a parenthetical dropped as contact
+ * details, say) is simply left unlinked rather than moved or invented.
+ */
+export const AuthorCredit = ({ author }: { author: string | null }) => {
+  if (!author) return null
+
+  const nodes: React.ReactNode[] = []
+  let cursor = 0
+
+  parseAuthorNames(author).forEach((name, index) => {
+    const at = author.indexOf(name, cursor)
+    const slug = authorSlug(name)
+    if (at < 0 || !slug) return
+
+    if (at > cursor) nodes.push(author.slice(cursor, at))
+    nodes.push(
+      <Link
+        key={`${slug}-${index}`}
+        href={authorHref(slug)}
+        className="text-accent hover:text-accent-hover"
+      >
+        {name}
+      </Link>
+    )
+    cursor = at + name.length
+  })
+
+  if (cursor < author.length) nodes.push(author.slice(cursor))
+
+  return <>{nodes}</>
+}

--- a/upload-site/app/components/AuthorCredit.tsx
+++ b/upload-site/app/components/AuthorCredit.tsx
@@ -1,14 +1,16 @@
 import Link from 'next/link'
-import { authorHref, authorSlug, parseAuthorNames } from '@/app/lib/authors'
+import { authorHref, authorSlug, parseAuthorCredits } from '@/app/lib/authors'
 
 /**
  * A package's author line, with every name in it linked to that author's page
  * and the rest of the credit left exactly as written - so "Akaya, mods by
  * Zooka" keeps saying that, while both names lead somewhere.
  *
- * The names come out of this very string, so each is found in it by scanning
- * forwards; a name that cannot be located (a parenthetical dropped as contact
- * details, say) is simply left unlinked rather than moved or invented.
+ * The parser reports where it read each name, and the line is cut at those
+ * points; the text between them is passed through untouched. Nothing is
+ * searched for, so a field that credits someone before naming its own author -
+ * "(mods by Zooka), Akaya" - links both, and a name that appears twice links
+ * the mention it was read from.
  */
 export const AuthorCredit = ({ author }: { author: string | null }) => {
   if (!author) return null
@@ -16,22 +18,21 @@ export const AuthorCredit = ({ author }: { author: string | null }) => {
   const nodes: React.ReactNode[] = []
   let cursor = 0
 
-  parseAuthorNames(author).forEach((name, index) => {
-    const at = author.indexOf(name, cursor)
-    const slug = authorSlug(name)
-    if (at < 0 || !slug) return
+  parseAuthorCredits(author).forEach((credit, index) => {
+    const slug = authorSlug(credit.name)
+    if (!slug || credit.at < cursor) return
 
-    if (at > cursor) nodes.push(author.slice(cursor, at))
+    if (credit.at > cursor) nodes.push(author.slice(cursor, credit.at))
     nodes.push(
       <Link
         key={`${slug}-${index}`}
         href={authorHref(slug)}
         className="text-accent hover:text-accent-hover"
       >
-        {name}
+        {author.slice(credit.at, credit.at + credit.length)}
       </Link>
     )
-    cursor = at + name.length
+    cursor = credit.at + credit.length
   })
 
   if (cursor < author.length) nodes.push(author.slice(cursor))

--- a/upload-site/app/components/Navigation.tsx
+++ b/upload-site/app/components/Navigation.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react'
 const LINKS = [
   { href: '/', label: 'Home' },
   { href: '/packages', label: 'All packages' },
+  { href: '/authors', label: 'Authors' },
   { href: '/stats', label: 'API usage' },
   { href: '/upload', label: 'Upload package' },
 ]

--- a/upload-site/app/components/PackageBrowser.tsx
+++ b/upload-site/app/components/PackageBrowser.tsx
@@ -2,6 +2,7 @@
 
 import { useDeferredValue, useMemo, useState } from 'react'
 import { UploadedPackageMetadata, UploadedPackageSortByOptions } from '@/app/lib/types'
+import { authorPackageCounts, authorSlug, parseAuthorNames } from '@/app/lib/authors'
 import { PackageCard } from './PackageCard'
 
 const SORTS = [
@@ -21,14 +22,16 @@ export const PackageBrowser = ({ packages }: { packages: UploadedPackageMetadata
   )
   const deferredQuery = useDeferredValue(query)
 
-  const authorCounts = useMemo(() => {
-    const counts = new Map<string, number>()
-    for (const pkg of packages) {
-      if (!pkg.author) continue
-      counts.set(pkg.author, (counts.get(pkg.author) ?? 0) + 1)
-    }
-    return counts
-  }, [packages])
+  // Counted per credited person rather than per author line, so a package
+  // shared by two authors counts towards both, and "Demonnic" and "demonnic"
+  // are one prolific author instead of two smaller ones.
+  const authorCounts = useMemo(() => authorPackageCounts(packages), [packages])
+
+  const packageAuthorCount = (pkg: UploadedPackageMetadata) =>
+    parseAuthorNames(pkg.author).reduce(
+      (highest, name) => Math.max(highest, authorCounts.get(authorSlug(name)) ?? 0),
+      0
+    )
 
   const visible = useMemo(() => {
     const needle = deferredQuery.trim().toLowerCase()
@@ -106,7 +109,7 @@ export const PackageBrowser = ({ packages }: { packages: UploadedPackageMetadata
         <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {visible.map((pkg) => (
             <li key={pkg.filename ?? pkg.mpackage}>
-              <PackageCard pkg={pkg} authorPackageCount={authorCounts.get(pkg.author ?? '') ?? 0} />
+              <PackageCard pkg={pkg} authorPackageCount={packageAuthorCount(pkg)} />
             </li>
           ))}
         </ul>

--- a/upload-site/app/components/ProgressBar.tsx
+++ b/upload-site/app/components/ProgressBar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { motion } from 'framer-motion'
 
 interface ProgressBarProps {
@@ -25,7 +26,9 @@ export function ProgressBar({ current, goal, authors }: ProgressBarProps) {
         <h2 className="text-lg font-semibold">Community packages</h2>
         <p className="text-sm text-muted">
           <span className="font-semibold text-foreground">{current}</span> packages from{' '}
-          <span className="font-semibold text-foreground">{authors}</span> authors
+          <Link href="/authors" className="font-semibold text-accent hover:text-accent-hover">
+            {authors} authors
+          </Link>
         </p>
       </div>
 

--- a/upload-site/app/lib/authors.ts
+++ b/upload-site/app/lib/authors.ts
@@ -26,57 +26,111 @@ const CREDIT_PREFIX = /^(?:[\p{L}][\p{L}\p{N}'’-]*\s+){0,3}by\s+/iu
 /** A parenthetical carrying contact details rather than a name. */
 const CONTACT = /@|https?:\/\/|www\.|\.(?:com|net|org|io|dev|eu)\b/i
 
-/** Punctuation that separates one credit from the next. */
-const SEPARATORS = /[,;&]+/
+/** Punctuation that separates one credit from the next, kept when splitting. */
+const SEPARATORS = /([,;&]+)/
 
-/** Leading or trailing punctuation left behind once a credit is split out. */
-const EDGE_PUNCTUATION = /^[\s\-–—:.·|]+|[\s\-–—:.·|]+$/g
+/** Punctuation left on the front or the back of a credit once it is split out. */
+const LEADING_EDGE = /^[\s\-–—:.·|]+/
+const TRAILING_EDGE = /[\s\-–—:.·|]+$/
+
+/** One person credited by an author field, and where it credits them. */
+export interface AuthorCreditRef {
+  /** The name, with runs of whitespace collapsed - what identifies the author. */
+  name: string
+  /** Where the credit begins in the author field it was read from. */
+  at: number
+  /** Its length there, so the field's own wording can be quoted back exactly. */
+  length: number
+}
 
 /**
- * The individual people credited by one `author` field, in the order they are
- * named, without repeats (case-insensitively - "Demonnic, demonnic" is one
- * person twice).
+ * The people credited by one `author` field, in the order the field names
+ * them, without repeats (case-insensitively - "Demonnic, demonnic" is one
+ * person twice; the first mention is the one kept).
+ *
+ * Each credit carries where it was found, so a caller rendering the field can
+ * mark up the names in place instead of searching for them afterwards - a
+ * search would have to guess which mention of a name it had reached.
  */
-export function parseAuthorNames(author: string | null | undefined): string[] {
+export function parseAuthorCredits(author: string | null | undefined): AuthorCreditRef[] {
   if (!author) return []
 
   // A parenthetical is either a credit of its own ("(mods by Zooka)"), contact
   // details that are not part of the name ("(caevorasmailbox@gmail.com)"), or
   // something this cannot read - which stays in the name, so that two authors
   // distinguished only by their parenthetical are not merged into one.
-  const credited: string[] = []
-  const remainder = author.replace(/\(([^)]*)\)/g, (whole, inner: string) => {
+  //
+  // The two it does read are blanked out of the field rather than removed from
+  // it: same length, so every index taken below still points into the original
+  // string, whichever end of the field the parenthetical sits at.
+  const segments: { text: string; at: number }[] = []
+  let outer = author
+
+  for (const match of author.matchAll(/\(([^)]*)\)/g)) {
+    const at = match.index
+    const inner = match[1]
     const trimmed = inner.trim()
-    if (CREDIT_PREFIX.test(trimmed)) {
-      credited.push(trimmed)
-      return ' '
-    }
-    return CONTACT.test(trimmed) ? ' ' : whole
-  })
+    const isCredit = CREDIT_PREFIX.test(trimmed)
+    if (!isCredit && !CONTACT.test(trimmed)) continue
 
-  const names: string[] = []
-  const seen = new Set<string>()
+    outer =
+      outer.slice(0, at) + ' '.repeat(match[0].length) + outer.slice(at + match[0].length)
+    if (isCredit) segments.push({ text: inner, at: at + 1 })
+  }
 
-  for (const part of [remainder, ...credited]) {
-    for (const segment of part.split(SEPARATORS)) {
-      // Trimmed before the credit phrase is stripped rather than after: the
-      // phrase is anchored to the start of the segment, and splitting on a
-      // comma leaves the space that followed it on the front.
-      const name = segment
-        .replace(/\s+/g, ' ')
-        .replace(EDGE_PUNCTUATION, '')
-        .replace(CREDIT_PREFIX, '')
-        .replace(EDGE_PUNCTUATION, '')
+  segments.unshift({ text: outer, at: 0 })
 
-      if (!name) continue
-      const key = name.toLowerCase()
-      if (seen.has(key)) continue
-      seen.add(key)
-      names.push(name)
+  const credits: AuthorCreditRef[] = []
+  for (const segment of segments) {
+    let offset = segment.at
+    for (const [index, piece] of segment.text.split(SEPARATORS).entries()) {
+      // split() with a capturing group hands back the separators too, so that
+      // what is skipped here still advances the offset past them.
+      if (index % 2 === 0) {
+        const credit = readCredit(piece, offset)
+        if (credit) credits.push(credit)
+      }
+      offset += piece.length
     }
   }
 
-  return names
+  credits.sort((a, b) => a.at - b.at)
+
+  const seen = new Set<string>()
+  return credits.filter((credit) => {
+    const key = credit.name.toLowerCase()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+/**
+ * One split-off piece of an author field, narrowed to the name inside it -
+ * measured rather than rewritten, so the caller keeps the offsets.
+ */
+function readCredit(piece: string, at: number): AuthorCreditRef | null {
+  let start = 0
+  let end = piece.length
+
+  // The credit phrase is anchored to the start of the piece, so the space that
+  // followed the comma comes off first.
+  start += piece.match(LEADING_EDGE)?.[0].length ?? 0
+  start += piece.slice(start, end).match(CREDIT_PREFIX)?.[0].length ?? 0
+  start += piece.slice(start, end).match(LEADING_EDGE)?.[0].length ?? 0
+  end -= piece.slice(start, end).match(TRAILING_EDGE)?.[0].length ?? 0
+
+  const name = piece.slice(start, end).replace(/\s+/g, ' ')
+  return name ? { name, at: at + start, length: end - start } : null
+}
+
+/**
+ * The names of the people credited by one `author` field, in the order it
+ * names them. Callers that need to know where each was written use
+ * parseAuthorCredits instead.
+ */
+export function parseAuthorNames(author: string | null | undefined): string[] {
+  return parseAuthorCredits(author).map((credit) => credit.name)
 }
 
 /**

--- a/upload-site/app/lib/authors.ts
+++ b/upload-site/app/lib/authors.ts
@@ -1,0 +1,179 @@
+import { UploadedPackageMetadata } from './types'
+
+/**
+ * The `author` field of an .mpackage is free text, and authors have used it as
+ * such: some name one person, some name several separated by commas, and some
+ * credit a second contributor in prose - "Akaya, mods by Zooka",
+ * "demonnic (mods by Zooka)", "Multiple DSL Contributors, Packaged by Zooka".
+ * Author pages are only useful if all of those land on the same person, so the
+ * field is split into individual credits here rather than treated as a name.
+ *
+ * The parsing is deliberately cautious: it splits on punctuation that can only
+ * be a separator, and leaves anything it cannot read confidently as a single
+ * name. "Adventurer1111 and Telepati's Mapping" stays whole, because " and "
+ * joins a credit to a component there rather than one person to another.
+ */
+
+/**
+ * A credit phrase in front of a name: "mods by Zooka", "Packaged by Zooka",
+ * "updated by Elene", or a bare "by Zooka". Up to three words may precede the
+ * "by" so unforeseen phrasings ("with additional work by ...") still resolve
+ * to the name; the "by" itself is required, so an ordinary name is never
+ * mistaken for a credit.
+ */
+const CREDIT_PREFIX = /^(?:[\p{L}][\p{L}\p{N}'’-]*\s+){0,3}by\s+/iu
+
+/** A parenthetical carrying contact details rather than a name. */
+const CONTACT = /@|https?:\/\/|www\.|\.(?:com|net|org|io|dev|eu)\b/i
+
+/** Punctuation that separates one credit from the next. */
+const SEPARATORS = /[,;&]+/
+
+/** Leading or trailing punctuation left behind once a credit is split out. */
+const EDGE_PUNCTUATION = /^[\s\-–—:.·|]+|[\s\-–—:.·|]+$/g
+
+/**
+ * The individual people credited by one `author` field, in the order they are
+ * named, without repeats (case-insensitively - "Demonnic, demonnic" is one
+ * person twice).
+ */
+export function parseAuthorNames(author: string | null | undefined): string[] {
+  if (!author) return []
+
+  // A parenthetical is either a credit of its own ("(mods by Zooka)"), contact
+  // details that are not part of the name ("(caevorasmailbox@gmail.com)"), or
+  // something this cannot read - which stays in the name, so that two authors
+  // distinguished only by their parenthetical are not merged into one.
+  const credited: string[] = []
+  const remainder = author.replace(/\(([^)]*)\)/g, (whole, inner: string) => {
+    const trimmed = inner.trim()
+    if (CREDIT_PREFIX.test(trimmed)) {
+      credited.push(trimmed)
+      return ' '
+    }
+    return CONTACT.test(trimmed) ? ' ' : whole
+  })
+
+  const names: string[] = []
+  const seen = new Set<string>()
+
+  for (const part of [remainder, ...credited]) {
+    for (const segment of part.split(SEPARATORS)) {
+      // Trimmed before the credit phrase is stripped rather than after: the
+      // phrase is anchored to the start of the segment, and splitting on a
+      // comma leaves the space that followed it on the front.
+      const name = segment
+        .replace(/\s+/g, ' ')
+        .replace(EDGE_PUNCTUATION, '')
+        .replace(CREDIT_PREFIX, '')
+        .replace(EDGE_PUNCTUATION, '')
+
+      if (!name) continue
+      const key = name.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      names.push(name)
+    }
+  }
+
+  return names
+}
+
+/**
+ * URL-safe identifier for an author, used as the /authors/[slug] segment, and
+ * as the identity two spellings of one name are merged under - which is what
+ * puts "Demonnic" and "demonnic" on the same page. Letters outside ASCII are
+ * kept rather than dropped, so a name written in a non-Latin script still has
+ * a slug of its own instead of an empty one.
+ */
+export function authorSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function authorHref(slug: string): string {
+  return `/authors/${encodeURIComponent(slug)}`
+}
+
+/** One author, and everything of theirs in the repository. */
+export interface AuthorSummary {
+  slug: string
+  /** The spelling most of their packages use. */
+  name: string
+  /** Every spelling seen, most used first - "Demonnic" as well as "demonnic". */
+  aliases: string[]
+  /** Their packages, most recently updated first. */
+  packages: UploadedPackageMetadata[]
+  /** Upload timestamp of the most recently updated one. */
+  latestUpload: number
+}
+
+/** Every author in the index, alphabetically. */
+export function collectAuthors(packages: UploadedPackageMetadata[]): AuthorSummary[] {
+  const bySlug = new Map<
+    string,
+    { slug: string; spellings: Map<string, number>; packages: UploadedPackageMetadata[] }
+  >()
+
+  for (const pkg of packages) {
+    for (const name of parseAuthorNames(pkg.author)) {
+      const slug = authorSlug(name)
+      // A "name" of nothing but punctuation has no page to link to.
+      if (!slug) continue
+
+      let entry = bySlug.get(slug)
+      if (!entry) {
+        entry = { slug, spellings: new Map(), packages: [] }
+        bySlug.set(slug, entry)
+      }
+      entry.spellings.set(name, (entry.spellings.get(name) ?? 0) + 1)
+      entry.packages.push(pkg)
+    }
+  }
+
+  return [...bySlug.values()]
+    .map((entry) => {
+      // Whichever spelling the author used most often wins; ties break
+      // alphabetically rather than on map order, so the name a page is built
+      // with does not depend on the order packages happened to be indexed in.
+      const aliases = [...entry.spellings.entries()]
+        .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+        .map(([spelling]) => spelling)
+      const sorted = entry.packages.slice().sort((a, b) => b.uploaded - a.uploaded)
+
+      return {
+        slug: entry.slug,
+        name: aliases[0],
+        aliases,
+        packages: sorted,
+        latestUpload: sorted.length ? sorted[0].uploaded : 0,
+      }
+    })
+    .sort((a, b) => a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }))
+}
+
+export function findAuthor(
+  packages: UploadedPackageMetadata[],
+  slug: string
+): AuthorSummary | null {
+  return collectAuthors(packages).find((author) => author.slug === slug) ?? null
+}
+
+/**
+ * How many packages each author has, keyed by slug - what tells a card that
+ * the author it names is a prolific one.
+ */
+export function authorPackageCounts(packages: UploadedPackageMetadata[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const pkg of packages) {
+    for (const name of parseAuthorNames(pkg.author)) {
+      const slug = authorSlug(name)
+      if (!slug) continue
+      counts.set(slug, (counts.get(slug) ?? 0) + 1)
+    }
+  }
+  return counts
+}

--- a/upload-site/app/packages/[name]/page.tsx
+++ b/upload-site/app/packages/[name]/page.tsx
@@ -13,6 +13,7 @@ import { PackageExplorer } from '@/app/components/PackageExplorer'
 import { InstallCommands } from '@/app/components/InstallCommands'
 import { DragToInstall } from '@/app/components/DragToInstall'
 import { PackageDescription } from '@/app/components/PackageDescription'
+import { AuthorCredit } from '@/app/components/AuthorCredit'
 import { formatDate, packageDownloadUrl, packageIconUrl, packageSlug } from '@/app/lib/urls'
 
 type PageProps = { params: Promise<{ name: string }> }
@@ -88,10 +89,10 @@ export default async function PackagePage({ params }: PageProps) {
   const iconUrl = packageIconUrl(pkg.icon)
   const facts = [
     pkg.version && { label: 'Version', value: pkg.version },
-    pkg.author && { label: 'Author', value: pkg.author },
+    pkg.author && { label: 'Author', value: <AuthorCredit author={pkg.author} /> },
     formatDate(pkg.created) && { label: 'Created', value: formatDate(pkg.created) as string },
     formatDate(pkg.uploaded) && { label: 'Updated', value: formatDate(pkg.uploaded) as string },
-  ].filter(Boolean) as { label: string; value: string }[]
+  ].filter(Boolean) as { label: string; value: React.ReactNode }[]
 
   return (
     <main className="py-8">

--- a/upload-site/app/page.tsx
+++ b/upload-site/app/page.tsx
@@ -4,6 +4,7 @@ import { IntroSection } from './components/IntroSection'
 import { ProgressBar } from './components/ProgressBar'
 import { CopyableCommand } from './components/CopyableCommand'
 import { fetchRepositoryPackages } from './lib/packages'
+import { collectAuthors } from './lib/authors'
 
 /**
  * The index used to carry this window on its own fetch; read off the checkout
@@ -16,7 +17,9 @@ const nextMilestone = (count: number) => Math.max(50, Math.ceil((count + 1) / 50
 
 export default async function Home() {
   const packages = await fetchRepositoryPackages()
-  const authors = new Set(packages.map((pkg) => pkg.author).filter(Boolean)).size
+  // Counted per person, not per author line: two packages credited to
+  // "Akaya" and "Akaya, mods by Zooka" are the work of two authors.
+  const authors = collectAuthors(packages).length
   const goal = nextMilestone(packages.length)
 
   const recent = packages

--- a/upload-site/next-sitemap.config.js
+++ b/upload-site/next-sitemap.config.js
@@ -43,6 +43,54 @@ function readPackageIndex() {
 const packageSlug = (name) =>
   (name || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
 
+/**
+ * Must stay in step with parseAuthorNames() and authorSlug() in
+ * app/lib/authors.ts - this config is CommonJS and cannot import the TypeScript
+ * the site itself uses, and a sitemap of author pages is only worth having if
+ * its URLs are the ones the app actually serves. See that file for why the
+ * author field is split at all.
+ */
+const CREDIT_PREFIX = /^(?:[\p{L}][\p{L}\p{N}'’-]*\s+){0,3}by\s+/iu
+const CONTACT = /@|https?:\/\/|www\.|\.(?:com|net|org|io|dev|eu)\b/i
+const EDGE_PUNCTUATION = /^[\s\-–—:.·|]+|[\s\-–—:.·|]+$/g
+
+function parseAuthorNames(author) {
+  if (!author) return []
+
+  const credited = []
+  const remainder = author.replace(/\(([^)]*)\)/g, (whole, inner) => {
+    const trimmed = inner.trim()
+    if (CREDIT_PREFIX.test(trimmed)) {
+      credited.push(trimmed)
+      return ' '
+    }
+    return CONTACT.test(trimmed) ? ' ' : whole
+  })
+
+  const names = []
+  const seen = new Set()
+  for (const part of [remainder, ...credited]) {
+    for (const segment of part.split(/[,;&]+/)) {
+      const name = segment
+        .replace(/\s+/g, ' ')
+        .replace(EDGE_PUNCTUATION, '')
+        .replace(CREDIT_PREFIX, '')
+        .replace(EDGE_PUNCTUATION, '')
+      if (!name || seen.has(name.toLowerCase())) continue
+      seen.add(name.toLowerCase())
+      names.push(name)
+    }
+  }
+  return names
+}
+
+const authorSlug = (name) =>
+  name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+
 /** reindex.lua writes `uploaded` as a unix timestamp in seconds. */
 function uploadedAt(pkg) {
   const seconds = Number(pkg && pkg.uploaded)
@@ -75,7 +123,7 @@ module.exports = {
     const uploads = packages.map(uploadedAt).filter(Boolean).sort()
     const newestUpload = uploads.length ? uploads[uploads.length - 1] : undefined
 
-    const listingPages = new Set(['/', '/packages'])
+    const listingPages = new Set(['/', '/packages', '/authors'])
 
     // Per-package detail pages live under the dynamic [name] route, which the
     // directory walk deliberately skips, so list them from the index.
@@ -83,12 +131,29 @@ module.exports = {
       .map((pkg) => ({ loc: `/packages/${packageSlug(pkg.mpackage)}`, lastmod: uploadedAt(pkg) }))
       .filter((entry) => entry.loc !== '/packages/')
 
+    // Same for author pages, which are as new as the newest package crediting
+    // them - a package with two authors dates both of their pages.
+    const authorLastmod = new Map()
+    for (const pkg of packages) {
+      const lastmod = uploadedAt(pkg)
+      for (const name of parseAuthorNames(pkg.author)) {
+        const slug = authorSlug(name)
+        if (!slug) continue
+        const known = authorLastmod.get(slug)
+        if (!known || (lastmod && lastmod > known)) authorLastmod.set(slug, lastmod)
+      }
+    }
+    const authorPaths = [...authorLastmod].map(([slug, lastmod]) => ({
+      loc: `/authors/${encodeURIComponent(slug)}`,
+      lastmod,
+    }))
+
     const staticPaths = ['/', ...getPathsFromDir(path.join(process.cwd(), 'app'))].map((loc) => ({
       loc,
       lastmod: listingPages.has(loc) ? newestUpload : undefined,
     }))
 
-    return [...staticPaths, ...packagePaths].map((entry) => ({
+    return [...staticPaths, ...packagePaths, ...authorPaths].map((entry) => ({
       loc: entry.loc,
       ...(entry.lastmod ? { lastmod: entry.lastmod } : {}),
     }))

--- a/upload-site/next-sitemap.config.js
+++ b/upload-site/next-sitemap.config.js
@@ -48,7 +48,9 @@ const packageSlug = (name) =>
  * app/lib/authors.ts - this config is CommonJS and cannot import the TypeScript
  * the site itself uses, and a sitemap of author pages is only worth having if
  * its URLs are the ones the app actually serves. See that file for why the
- * author field is split at all.
+ * author field is split at all. Only the names matter here, never the order
+ * they were written in, so this keeps none of the offset bookkeeping that
+ * marking the names up in place needs.
  */
 const CREDIT_PREFIX = /^(?:[\p{L}][\p{L}\p{N}'’-]*\s+){0,3}by\s+/iu
 const CONTACT = /@|https?:\/\/|www\.|\.(?:com|net|org|io|dev|eu)\b/i


### PR DESCRIPTION
The author field of an .mpackage is free text, and authors have used it as such: some name one person, some several separated by commas, and some credit a second contributor in prose - "Akaya, mods by Zooka", "demonnic (mods by Zooka)", "Multiple DSL Contributors, Packaged by Zooka". Read as a name, each of those is a stranger, which is why the site could only ever say who wrote a package and never show the rest of their work.

So split the field into the people it credits: on punctuation that can only be a separator, and on a credit phrase in front of a name. What cannot be read confidently is left whole - "Adventurer1111 and Telepati's Mapping" joins a credit to a component rather than one person to another, and splitting it would invent an author. Spellings merge case-insensitively, so Demonnic's 29 packages are no longer two authors with 16 and 11.

That gives /authors, which lists everyone and what they have made, and /authors/[slug], which collects an author's packages along with whoever they shared them with. Package pages link the names inside their author line in place, so the credit still reads "Akaya, mods by Zooka" with both names leading somewhere. Unpacking no archives, the author pages prerender whether or not the checkout is there to read.