### PR TITLE
Let a package's own CI publish it, with no stored credential

### DIFF
--- a/.github/scripts/validate-trusted-publishers.mjs
+++ b/.github/scripts/validate-trusted-publishers.mjs
@@ -13,6 +13,7 @@
  */
 
 import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 
 const path = process.argv[2] ?? 'trusted-publishers.json'
 const problems = []
@@ -41,6 +42,7 @@ const REQUIRED = ['mpackage', 'filename', 'repository', 'repositoryId', 'reposit
 const KNOWN = new Set([...REQUIRED, 'ref', 'environment', 'allowSelfHostedRunner'])
 
 const seen = new Map()
+const seenFiles = new Map()
 
 for (const [index, entry] of registry.publishers.entries()) {
   const label = entry?.mpackage ? `${index}: ${entry.mpackage}` : String(index)
@@ -87,6 +89,47 @@ for (const [index, entry] of registry.publishers.entries()) {
       note(label, `duplicates the entry at index ${seen.get(key)} for the same package`)
     } else {
       seen.set(key, index)
+    }
+  }
+
+  // Two entries for one file are two packages publishing over each other:
+  // every check at publish time is against the entry's own ids and its own
+  // package name, so nothing there notices that the archive lands on somebody
+  // else's path. This is where it has to be caught.
+  if (typeof entry.filename === 'string') {
+    const key = entry.filename.trim().toLowerCase()
+    if (seenFiles.has(key)) {
+      note(label, `"filename" is also claimed by the entry at index ${seenFiles.get(key)}`)
+    } else {
+      seenFiles.set(key, index)
+    }
+  }
+}
+
+// And the same collision against packages already published. The index names
+// the file each package occupies; an entry pointing at one of them for a
+// different package would publish straight over it.
+const indexPath = join(dirname(path), 'packages', 'mpkg.packages.json')
+const index = await readFile(indexPath, 'utf8').then(
+  (text) => JSON.parse(text).packages,
+  // Not every checkout has a generated index, and a validator that cannot read
+  // one has nothing to say about it either way.
+  () => null,
+)
+
+if (Array.isArray(index)) {
+  for (const [index_, entry] of registry.publishers.entries()) {
+    if (typeof entry?.filename !== 'string' || typeof entry?.mpackage !== 'string') continue
+    const occupied = index.find(
+      (pkg) =>
+        String(pkg?.filename ?? '').trim().toLowerCase() === entry.filename.trim().toLowerCase() &&
+        String(pkg?.mpackage ?? '').trim().toLowerCase() !== entry.mpackage.trim().toLowerCase(),
+    )
+    if (occupied) {
+      note(
+        `${index_}: ${entry.mpackage}`,
+        `"filename" is packages/${entry.filename}, which is already the file of "${occupied.mpackage}"`,
+      )
     }
   }
 }

--- a/.github/scripts/validate-trusted-publishers.mjs
+++ b/.github/scripts/validate-trusted-publishers.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Checks trusted-publishers.json.
+ *
+ * An entry in that file grants a workflow the right to publish a package, so a
+ * typo in it is a security-relevant mistake rather than a cosmetic one: an id
+ * that belongs to the wrong repository hands publish rights to whoever owns
+ * that repository. This verifies the shape of every entry and confirms each
+ * pair of ids really is the repository the entry names.
+ *
+ * Usage: node .github/scripts/validate-trusted-publishers.mjs [path]
+ * Set GITHUB_TOKEN to avoid the unauthenticated API rate limit.
+ */
+
+import { readFile } from 'node:fs/promises'
+
+const path = process.argv[2] ?? 'trusted-publishers.json'
+const problems = []
+const note = (entry, message) =>
+  problems.push(`${entry === null ? path : `${path} [${entry}]`}: ${message}`)
+
+const raw = await readFile(path, 'utf8').catch((error) => {
+  console.error(`cannot read ${path}: ${error.message}`)
+  process.exit(1)
+})
+
+let registry
+try {
+  registry = JSON.parse(raw)
+} catch (error) {
+  console.error(`${path} is not valid JSON: ${error.message}`)
+  process.exit(1)
+}
+
+if (!registry || !Array.isArray(registry.publishers)) {
+  console.error(`${path} has no "publishers" array`)
+  process.exit(1)
+}
+
+const REQUIRED = ['mpackage', 'filename', 'repository', 'repositoryId', 'repositoryOwnerId', 'workflow']
+const KNOWN = new Set([...REQUIRED, 'ref', 'environment', 'allowSelfHostedRunner'])
+
+const seen = new Map()
+
+for (const [index, entry] of registry.publishers.entries()) {
+  const label = entry?.mpackage ? `${index}: ${entry.mpackage}` : String(index)
+
+  if (typeof entry !== 'object' || entry === null) {
+    note(label, 'is not an object')
+    continue
+  }
+
+  for (const field of REQUIRED) {
+    if (typeof entry[field] !== 'string' || !entry[field].trim()) {
+      note(label, `"${field}" must be a non-empty string`)
+    }
+  }
+  for (const key of Object.keys(entry)) {
+    if (!KNOWN.has(key)) note(label, `unknown key "${key}"`)
+  }
+  if ('allowSelfHostedRunner' in entry && typeof entry.allowSelfHostedRunner !== 'boolean') {
+    note(label, '"allowSelfHostedRunner" must be a boolean')
+  }
+
+  if (typeof entry.repository === 'string' && !/^[^/\s]+\/[^/\s]+$/.test(entry.repository)) {
+    note(label, `"repository" should be "owner/repo", got "${entry.repository}"`)
+  }
+  for (const field of ['repositoryId', 'repositoryOwnerId']) {
+    if (typeof entry[field] === 'string' && !/^\d+$/.test(entry[field])) {
+      note(label, `"${field}" must be GitHub's numeric id as a string`)
+    }
+  }
+  if (typeof entry.filename === 'string' && !/^[^/\\]+\.(mpackage|zip)$/i.test(entry.filename)) {
+    note(label, `"filename" must be a plain .mpackage or .zip file name, got "${entry.filename}"`)
+  }
+  if (typeof entry.workflow === 'string' && !/^\.github\/workflows\/[^/]+\.ya?ml$/.test(entry.workflow)) {
+    note(label, `"workflow" must be a path like ".github/workflows/publish.yml", got "${entry.workflow}"`)
+  }
+  if (entry.ref != null && typeof entry.ref === 'string' && !entry.ref.startsWith('refs/')) {
+    note(label, `"ref" must be a full ref such as "refs/heads/main", got "${entry.ref}"`)
+  }
+
+  // Two entries for one package name would make authorisation order-dependent.
+  if (typeof entry.mpackage === 'string') {
+    const key = entry.mpackage.trim().toLowerCase()
+    if (seen.has(key)) {
+      note(label, `duplicates the entry at index ${seen.get(key)} for the same package`)
+    } else {
+      seen.set(key, index)
+    }
+  }
+}
+
+// The ids are the thing actually matched, so confirm they are the repository
+// the entry claims. A mismatch means the entry grants rights to someone else.
+const headers = { accept: 'application/vnd.github+json' }
+if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+
+for (const [index, entry] of registry.publishers.entries()) {
+  if (typeof entry?.repository !== 'string' || typeof entry?.repositoryId !== 'string') continue
+  const label = `${index}: ${entry.mpackage ?? '?'}`
+
+  let response
+  try {
+    response = await fetch(`https://api.github.com/repos/${entry.repository}`, { headers })
+  } catch (error) {
+    note(label, `could not reach the GitHub API: ${error.message}`)
+    continue
+  }
+
+  if (response.status === 404) {
+    note(label, `repository ${entry.repository} does not exist or is private`)
+    continue
+  }
+  if (!response.ok) {
+    note(label, `GitHub API returned HTTP ${response.status} for ${entry.repository}`)
+    continue
+  }
+
+  const repo = await response.json()
+  if (String(repo.id) !== entry.repositoryId) {
+    note(label, `repositoryId is ${entry.repositoryId} but ${entry.repository} is ${repo.id}`)
+  }
+  if (String(repo.owner?.id) !== entry.repositoryOwnerId) {
+    note(label, `repositoryOwnerId is ${entry.repositoryOwnerId} but ${repo.owner?.login} is ${repo.owner?.id}`)
+  }
+}
+
+if (problems.length) {
+  console.error(`${problems.length} problem(s) found:\n`)
+  for (const problem of problems) console.error(`  - ${problem}`)
+  process.exit(1)
+}
+
+console.log(`${path}: ${registry.publishers.length} publisher(s), all valid`)

--- a/.github/workflows/auto-merge-packages.yml
+++ b/.github/workflows/auto-merge-packages.yml
@@ -60,6 +60,15 @@ jobs:
             const SELF_CHECK_NAME = 'auto-merge';
             const GREPTILE_LOGIN = 'greptile-apps[bot]';
             const PACKAGE_FILE_RE = /^packages\/[^/]+\.(mpackage|zip)$/;
+            // A trusted publish records where the archive came from, pinned to
+            // its digest, so it writes the package's file under provenance/ as
+            // well as the package itself. Those files are what the site's
+            // "built and published from source" panel trusts, so one is in
+            // scope for exactly these pull requests and no others - and only
+            // ever the one belonging to the package being published.
+            const provenanceFileFor = (pkg) => `provenance/${pkg.replace(/^packages\//, '')}.json`;
+            const MACHINE_ACCOUNT = 'mudlet-machine-account';
+            const TRUSTED_BRANCH_PREFIX = 'trusted-publish/';
 
             const skip = (msg) => { core.notice(`auto-merge: skip — ${msg}`); };
 
@@ -102,8 +111,29 @@ jobs:
                 owner, repo, pull_number: prNumber, per_page: 100,
               });
               if (files.length === 0) return skip('PR changes no files');
+
+              // Only the package site can create a branch in this repository,
+              // and it names trusted-publish branches itself, so a fork PR can
+              // never satisfy all three of these - which is what keeps
+              // provenance records out of reach of anyone submitting by hand.
+              const isTrustedPublish =
+                pr.head.repo && pr.head.repo.full_name === `${owner}/${repo}` &&
+                pr.head.ref.startsWith(TRUSTED_BRANCH_PREFIX) &&
+                pr.user && pr.user.login === MACHINE_ACCOUNT;
+
+              // Tie the provenance file to the package in this same PR, so an
+              // authorised publish still cannot write a record vouching for
+              // some other package.
+              const allowedProvenance = new Set(
+                isTrustedPublish
+                  ? files.filter(f => PACKAGE_FILE_RE.test(f.filename))
+                         .map(f => provenanceFileFor(f.filename))
+                  : []);
+
               for (const f of files) {
-                if (!PACKAGE_FILE_RE.test(f.filename)) {
+                const inScope = PACKAGE_FILE_RE.test(f.filename) ||
+                  allowedProvenance.has(f.filename);
+                if (!inScope) {
                   return skip(`file outside package scope: ${f.filename}`);
                 }
                 if (f.status !== 'added' && f.status !== 'modified') {

--- a/.github/workflows/validate-mpackage.yml
+++ b/.github/workflows/validate-mpackage.yml
@@ -40,11 +40,33 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
       run: |
-        FILE=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path')
-        
-        # check only 1 file has been uploaded per PR
-        if [ `echo "$FILE" |wc -l` -gt 1 ]; then
+        # Statuses matter here, so this reads the API rather than `gh pr view`:
+        # publishing a package under a new filename deletes the old one in the
+        # same pull request, and that deletion must not count towards the limit.
+        PATHS=$(gh api --paginate \
+          "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+          --jq '.[] | select(.status != "removed") | .filename')
+
+        PACKAGE_RE='^packages/[^/]+\.(mpackage|zip)$'
+        FILE=$(echo "$PATHS" | grep -E "$PACKAGE_RE" || true)
+
+        # A trusted publish also records where the archive came from, pinned to
+        # its digest (see TRUSTED-PUBLISHING.md), so the package's own file
+        # under provenance/ may ride along. Nothing else may.
+        OTHER=$(echo "$PATHS" | grep -vE "$PACKAGE_RE|^provenance/[^/]+\.json$" || true)
+        if [ -n "$OTHER" ]; then
+          echo "Error: this pull request changes files that are not a package:"
+          echo "$OTHER" | sed 's/^/  /'
+          exit 1
+        fi
+
+        # check only 1 package file has been uploaded per PR
+        COUNT=$(echo "$FILE" | grep -c . || true)
+        if [ "$COUNT" -gt 1 ]; then
           echo "Error: Only one package file per pull request please."
+          exit 1
+        elif [ "$COUNT" -eq 0 ]; then
+          echo "Error: no package file found in this pull request."
           exit 1
         else
           echo "Pass: just one file uploaded."

--- a/.github/workflows/validate-mpackage.yml
+++ b/.github/workflows/validate-mpackage.yml
@@ -50,16 +50,6 @@ jobs:
         PACKAGE_RE='^packages/[^/]+\.(mpackage|zip)$'
         FILE=$(echo "$PATHS" | grep -E "$PACKAGE_RE" || true)
 
-        # A trusted publish also records where the archive came from, pinned to
-        # its digest (see TRUSTED-PUBLISHING.md), so the package's own file
-        # under provenance/ may ride along. Nothing else may.
-        OTHER=$(echo "$PATHS" | grep -vE "$PACKAGE_RE|^provenance/[^/]+\.json$" || true)
-        if [ -n "$OTHER" ]; then
-          echo "Error: this pull request changes files that are not a package:"
-          echo "$OTHER" | sed 's/^/  /'
-          exit 1
-        fi
-
         # check only 1 package file has been uploaded per PR
         COUNT=$(echo "$FILE" | grep -c . || true)
         if [ "$COUNT" -gt 1 ]; then
@@ -68,9 +58,23 @@ jobs:
         elif [ "$COUNT" -eq 0 ]; then
           echo "Error: no package file found in this pull request."
           exit 1
-        else
-          echo "Pass: just one file uploaded."
         fi
+
+        # A trusted publish also records where the archive came from, pinned to
+        # its digest (see TRUSTED-PUBLISHING.md), so the package's own record
+        # under provenance/ may ride along - that one file and no other. Named
+        # exactly rather than matched by shape: "any provenance/*.json" let a
+        # pull request carry records for packages it does not touch.
+        ALLOWED_PROVENANCE="provenance/$(basename "$FILE").json"
+        OTHER=$(echo "$PATHS" | grep -vE "$PACKAGE_RE" | grep -vxF "$ALLOWED_PROVENANCE" || true)
+        if [ -n "$OTHER" ]; then
+          echo "Error: this pull request changes files that are not a package:"
+          echo "$OTHER" | sed 's/^/  /'
+          echo "The only file that may accompany one is $ALLOWED_PROVENANCE."
+          exit 1
+        fi
+
+        echo "Pass: just one file uploaded."
 
         echo "FILE=$FILE" >> $GITHUB_OUTPUT
       

--- a/.github/workflows/validate-trusted-publishers.yml
+++ b/.github/workflows/validate-trusted-publishers.yml
@@ -1,0 +1,35 @@
+name: Validate trusted publishers
+
+# An entry in trusted-publishers.json grants a workflow the right to publish a
+# package, so it gets checked like a credential: the shape of every entry, and
+# whether each pair of GitHub ids really belongs to the repository it names.
+#
+# This file is outside packages/, so auto-merge-packages.yml will not merge a
+# change to it - a maintainer always reviews one.
+
+on:
+  pull_request:
+    paths:
+      - 'trusted-publishers.json'
+      - '.github/scripts/validate-trusted-publishers.mjs'
+  push:
+    branches: [main]
+    paths:
+      - 'trusted-publishers.json'
+      - '.github/scripts/validate-trusted-publishers.mjs'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Check trusted-publishers.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/validate-trusted-publishers.mjs

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Contribute your mpackage using Github's "[fork and pull request](https://docs.gi
 - copy your mpackage to the cloned repository subdirectory `packages/` (no further files need to be changed, Github workflows take care of rebuilding the repository index),
 - commit, push and submit a pull request.
 
+#### via Trusted Publishing (from your CI) ####
+
+If your package is built by GitHub Actions, its workflow can publish new versions
+by itself, with no token stored anywhere: it presents the short-lived OIDC token
+GitHub mints for the run, and a maintainer-reviewed entry in
+[`trusted-publishers.json`](trusted-publishers.json) says which workflow is allowed
+to act for which package. The result is an ordinary pull request, reviewed as usual.
+
+See [TRUSTED-PUBLISHING.md](TRUSTED-PUBLISHING.md) to set it up.
+
 ### Development ###
 
 Using Docker, run `./mpkg/muddle` or run Muddler [manually](https://github.com/demonnic/muddler/wiki/Installation) to generate the new `./mpkg/build/mpkg.mpackage` file can be loaded into Mudlet as a module.

--- a/TRUSTED-PUBLISHING.md
+++ b/TRUSTED-PUBLISHING.md
@@ -168,6 +168,18 @@ badge trusts, so they are kept out of reach of anything else:
 A maintainer merging a hand-made pull request that touches anything under
 `provenance/` should treat it exactly like a change to `trusted-publishers.json`.
 
+### Renaming a package's file needs a manual merge
+
+If the `filename` in a publisher's entry changes, the next publish deletes the
+old archive and its record as well as adding the new pair. Auto-merge only
+accepts files with status `added` or `modified`, so a pull request containing
+those deletions will pass validation and then wait for a maintainer.
+
+That is the pre-existing rule and it applies to a rename through the upload form
+too. It is left alone deliberately: renames are rare — they only happen when a
+maintainer edits the registry — and teaching the auto-merge gate to accept
+deletions is a wider change to what can land unattended than the case justifies.
+
 ## What the endpoint checks
 
 In order, and the request stops at the first failure:

--- a/TRUSTED-PUBLISHING.md
+++ b/TRUSTED-PUBLISHING.md
@@ -99,6 +99,10 @@ The artifact is passed as a URL rather than uploaded, so a large package does
 not run into the request body limits on the site, and the URL must be a release
 asset of the same repository the token was issued to.
 
+One workflow may publish several packages: give each its own entry, all naming
+the same `workflow`. Which entry a run is acting under is decided by the
+`mpackage` in the `config.lua` it uploads.
+
 ### Reusable workflows are not supported
 
 The registry pins `job_workflow_ref`, which names the workflow file that
@@ -123,6 +127,11 @@ review it like a credential. Worth checking:
 - **The package is theirs.** An entry for a package someone else already
   publishes is refused at publish time (the author in `config.lua` must match
   the index), but it should not get that far.
+- **The `filename` is theirs too.** It is the path the archive lands on, and
+  nothing about the rest of the entry constrains it: an entry that names another
+  package's file would publish over that file. `validate-trusted-publishers.yml`
+  rejects one that collides with another entry or with a published package, and
+  the endpoint refuses it as well, but the diff is where it is obvious.
 
 `trusted-publishers.json` is outside `packages/`, so the auto-merge workflow —
 which only ever touches `packages/*.mpackage` and `packages/*.zip` — will not
@@ -130,9 +139,15 @@ merge a change to it.
 
 ## Provenance, and why the badge is not driven by this file
 
-A package published this way gets a "Built and published from source" panel on
-its page, linking the repository, the workflow file and the commit it was built
-from.
+A package published this way gets a "Published from source by CI" panel on its
+page, linking the repository, the workflow file and the commit the run was on.
+
+The panel says *published*, not *built*, because that is what the record can
+support: a release asset can be attached to a release by hand. What is proven is
+that these exact bytes were submitted by that run, from that repository, by that
+workflow file. A run on a tag is pinned further — the asset must belong to that
+tag's own release — but a run on a branch can offer any asset the repository
+has.
 
 That panel is deliberately **not** driven by `trusted-publishers.json`. This
 file records an intention, decided before any archive exists — it cannot say how
@@ -159,7 +174,8 @@ same path.
 This is why a trusted publish changes two files. Those records are what the
 badge trusts, so they are kept out of reach of anything else:
 
-- `validate-mpackage.yml` allows one to accompany a package, and still rejects
+- `validate-mpackage.yml` allows the record *for that package* to accompany it —
+  `provenance/<the file in packages/>.json`, named exactly — and still rejects
   any other extra file, and still allows only one package per pull request.
 - `auto-merge-packages.yml` allows one in scope **only** when the pull request
   comes from a `trusted-publish/*` branch in this repository, opened by the
@@ -188,21 +204,26 @@ In order, and the request stops at the first failure:
 
 1. The token is signed by `https://token.actions.githubusercontent.com`, has
    audience `https://packages.mudlet.org`, and is under 15 minutes old.
-2. `repository_id` and `repository_owner_id` match a registry entry.
+2. `repository_id` and `repository_owner_id` match at least one registry entry.
 3. `job_workflow_ref` names the registered workflow file, character for
-   character.
-4. `ref`, `environment` and runner type match, where the entry constrains them.
-5. `artifactUrl` is an HTTPS release asset of the repository in the token.
-6. The archive holds a `config.lua` with all six required fields.
-7. `config.lua`'s `mpackage` is the package the entry is for.
-8. If that package is already in the index, its author matches.
+   character. What is left is every entry that workflow may publish.
+4. `artifactUrl` is an HTTPS release asset of the repository in the token — and
+   of that tag's own release, when the run is on a tag.
+5. The archive holds a `config.lua` with all six required fields.
+6. `config.lua`'s `mpackage` picks one of those entries. That is the publisher.
+7. `ref`, `environment` and runner type match, where **that entry** constrains
+   them.
+8. `packages/<filename>` is not already some other package's file.
+9. If the package is already in the index, its author matches.
 
 It then opens a pull request adding the archive and recording its digest under
 `provenance/`.
 
-A token is accepted once. Calling twice from one workflow run — a retry whose
-first reply was lost, say — answers `409` with the pull request the earlier call
-already opened, in the same `pullRequest` field a success returns.
+A token is accepted once, and a workflow run gets one pull request. Calling
+twice from one run — a retry whose first reply was lost, say — answers `409`:
+with the earlier pull request in the same `pullRequest` field a success returns,
+when that call got far enough to open one, and with `This token has already been
+used` when the retry re-sent the very same token.
 
 The audience pin means a token minted for some other service cannot be
 forwarded here, and a token minted for us is useless anywhere else.

--- a/TRUSTED-PUBLISHING.md
+++ b/TRUSTED-PUBLISHING.md
@@ -1,0 +1,189 @@
+# Trusted publishing
+
+A package's own GitHub Actions workflow can publish new versions to this
+repository without anyone storing a token anywhere.
+
+Instead of a personal access token, the workflow asks GitHub for a short-lived
+OIDC token describing that particular run — which repository, which workflow
+file, which commit — and sends it to `https://packages.mudlet.org/api/publish`.
+The site verifies the token against GitHub's public keys, checks the run against
+[`trusted-publishers.json`](trusted-publishers.json), and opens the same kind of
+pull request the upload form does.
+
+Nothing about review changes. A trusted publish still lands as a pull request,
+still runs `Validate mpackage file`, and still needs whatever the auto-merge
+workflow requires. Trusted publishing changes who may *ask* for a package to be
+updated, never what is allowed to land.
+
+## For package authors
+
+### 1. Ask a maintainer to register your workflow
+
+Open a pull request adding an entry to `trusted-publishers.json`:
+
+```json
+{
+  "mpackage": "yourpackage",
+  "filename": "yourpackage.mpackage",
+  "repository": "you/yourrepo",
+  "repositoryId": "80291515",
+  "repositoryOwnerId": "1749428",
+  "workflow": ".github/workflows/publish.yml"
+}
+```
+
+Get the two ids with:
+
+```sh
+curl -s https://api.github.com/repos/OWNER/REPO | jq '.id, .owner.id'
+```
+
+They are matched instead of the repository name because names move: a
+repository can be renamed, transferred, or deleted and recreated by somebody
+else, and every one of those leaves the old `owner/repo` string pointing
+somewhere new. The numeric ids do not move.
+
+Two optional keys tighten things further:
+
+| Key | Effect |
+| --- | --- |
+| `ref` | Only publish from this exact ref, e.g. `refs/heads/main`. |
+| `environment` | Only publish from a job in this GitHub environment. Give the environment required reviewers and a publish needs a human to approve it. |
+| `allowSelfHostedRunner` | Permit self-hosted runners. Off by default — they are outside GitHub's control. |
+
+### 2. Publish from your workflow
+
+Attach the `.mpackage` to a GitHub release, then:
+
+```yaml
+name: Publish to Mudlet package repository
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write     # required: lets the job mint an OIDC token
+      contents: read
+    steps:
+      - name: Publish
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const token = await core.getIDToken('https://packages.mudlet.org')
+            const asset = context.payload.release.assets
+              .find(a => a.name.endsWith('.mpackage'))
+            if (!asset) throw new Error('no .mpackage asset on this release')
+
+            const response = await fetch('https://packages.mudlet.org/api/publish', {
+              method: 'POST',
+              headers: {
+                authorization: `Bearer ${token}`,
+                'content-type': 'application/json',
+              },
+              body: JSON.stringify({ artifactUrl: asset.browser_download_url }),
+            })
+
+            const result = await response.json()
+            if (!response.ok) throw new Error(result.error || `HTTP ${response.status}`)
+            core.notice(`Opened ${result.pullRequest}`)
+```
+
+`permissions: id-token: write` is what allows `core.getIDToken`. Without it the
+step fails with "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL".
+
+The artifact is passed as a URL rather than uploaded, so a large package does
+not run into the request body limits on the site, and the URL must be a release
+asset of the same repository the token was issued to.
+
+### Reusable workflows are not supported
+
+The registry pins `job_workflow_ref`, which names the workflow file that
+actually contains the running job. If you move the publish step into a reusable
+workflow, that claim names the reusable workflow instead of yours and the
+request is refused. Keep the publishing job in your own workflow file.
+
+This is deliberate: pinning only the repository would let *any* workflow anyone
+lands in it publish, and a pull request is often enough to add one.
+
+## For maintainers
+
+Adding an entry to `trusted-publishers.json` is what grants publish rights, so
+review it like a credential. Worth checking:
+
+- **The ids are right.** Fetch them yourself rather than trusting the diff.
+- **The workflow path is the one they described**, and lives in the repository
+  the ids point at.
+- **The person asking controls that repository.** The registry cannot tell.
+- **The package is theirs.** An entry for a package someone else already
+  publishes is refused at publish time (the author in `config.lua` must match
+  the index), but it should not get that far.
+
+`trusted-publishers.json` is outside `packages/`, so the auto-merge workflow —
+which only ever touches `packages/*.mpackage` and `packages/*.zip` — will not
+merge a change to it.
+
+## Provenance, and why the badge is not driven by this file
+
+A package published this way gets a "Built and published from source" panel on
+its page, linking the repository, the workflow file and the commit it was built
+from.
+
+That panel is deliberately **not** driven by `trusted-publishers.json`. This
+file records an intention, decided before any archive exists — it cannot say how
+the file currently sitting in `packages/` got there. A registered package can
+still be replaced by a website upload, an ordinary fork-and-pull-request, or a
+maintainer committing directly, and a badge reading the registry would go on
+vouching for the origin of a file nobody checked.
+
+So the publish endpoint writes a record under `provenance/`, one file per
+package — `provenance/arkadia.mpackage.json` for `packages/arkadia.mpackage` —
+holding the archive's **sha-256** alongside the repository, workflow, commit and
+run that produced it. The site hashes the archive it is actually serving and
+shows the panel only if it matches. Replace those bytes by any route and the
+record stops describing the file, so the badge disappears on its own. It fails
+closed, and nobody has to remember to revoke anything.
+
+One file per package rather than one shared registry, because a shared file does
+not survive concurrent use: two packages publishing at the same time would be
+editing it on two branches cut from the same commit, and whichever merged second
+would land in conflict — which auto-merge declines to touch, so both would sit
+there until someone rebased them by hand. Sharded, two publishes never write the
+same path.
+
+This is why a trusted publish changes two files. Those records are what the
+badge trusts, so they are kept out of reach of anything else:
+
+- `validate-mpackage.yml` allows one to accompany a package, and still rejects
+  any other extra file, and still allows only one package per pull request.
+- `auto-merge-packages.yml` allows one in scope **only** when the pull request
+  comes from a `trusted-publish/*` branch in this repository, opened by the
+  machine account — and then only the record belonging to the package in that
+  same pull request. Only the site can create a branch here, so a pull request
+  from a fork can never meet that condition.
+
+A maintainer merging a hand-made pull request that touches anything under
+`provenance/` should treat it exactly like a change to `trusted-publishers.json`.
+
+## What the endpoint checks
+
+In order, and the request stops at the first failure:
+
+1. The token is signed by `https://token.actions.githubusercontent.com`, has
+   audience `https://packages.mudlet.org`, and is under 15 minutes old.
+2. `repository_id` and `repository_owner_id` match a registry entry.
+3. `job_workflow_ref` names the registered workflow file.
+4. `ref`, `environment` and runner type match, where the entry constrains them.
+5. `artifactUrl` is an HTTPS release asset of the repository in the token.
+6. The archive holds a `config.lua` with all six required fields.
+7. `config.lua`'s `mpackage` is the package the entry is for.
+8. If that package is already in the index, its author matches.
+
+It then opens a pull request adding the archive and recording its digest under
+`provenance/`.
+
+The audience pin means a token minted for some other service cannot be
+forwarded here, and a token minted for us is useless anywhere else.

--- a/TRUSTED-PUBLISHING.md
+++ b/TRUSTED-PUBLISHING.md
@@ -197,5 +197,9 @@ In order, and the request stops at the first failure:
 It then opens a pull request adding the archive and recording its digest under
 `provenance/`.
 
+A token is accepted once. Calling twice from one workflow run — a retry whose
+first reply was lost, say — answers `409` with the pull request the earlier call
+already opened, in the same `pullRequest` field a success returns.
+
 The audience pin means a token minted for some other service cannot be
 forwarded here, and a token minted for us is useless anywhere else.

--- a/TRUSTED-PUBLISHING.md
+++ b/TRUSTED-PUBLISHING.md
@@ -116,7 +116,9 @@ review it like a credential. Worth checking:
 
 - **The ids are right.** Fetch them yourself rather than trusting the diff.
 - **The workflow path is the one they described**, and lives in the repository
-  the ids point at.
+  the ids point at — spelled exactly as the file is. The match is
+  case-sensitive, so a run from `Publish.yml` does not satisfy an entry for
+  `publish.yml`.
 - **The person asking controls that repository.** The registry cannot tell.
 - **The package is theirs.** An entry for a package someone else already
   publishes is refused at publish time (the author in `config.lua` must match
@@ -187,7 +189,8 @@ In order, and the request stops at the first failure:
 1. The token is signed by `https://token.actions.githubusercontent.com`, has
    audience `https://packages.mudlet.org`, and is under 15 minutes old.
 2. `repository_id` and `repository_owner_id` match a registry entry.
-3. `job_workflow_ref` names the registered workflow file.
+3. `job_workflow_ref` names the registered workflow file, character for
+   character.
 4. `ref`, `environment` and runner type match, where the entry constrains them.
 5. `artifactUrl` is an HTTPS release asset of the repository in the token.
 6. The archive holds a `config.lua` with all six required fields.

--- a/trusted-publishers.json
+++ b/trusted-publishers.json
@@ -1,0 +1,23 @@
+{
+  "_readme": [
+    "Trusted publishers: GitHub Actions workflows allowed to publish a package",
+    "without anyone storing a credential. See TRUSTED-PUBLISHING.md.",
+    "",
+    "Adding an entry here grants publish rights, so every change to this file",
+    "needs a maintainer's review - it is never auto-merged.",
+    "",
+    "repositoryId and repositoryOwnerId are GitHub's numeric ids and are what a",
+    "token is matched against; the repository name is for humans. Read them with:",
+    "  curl -s https://api.github.com/repos/OWNER/REPO | jq '.id, .owner.id'"
+  ],
+  "publishers": [
+    {
+      "mpackage": "arkadia",
+      "filename": "arkadia.mpackage",
+      "repository": "tjurczyk/arkadia",
+      "repositoryId": "80291515",
+      "repositoryOwnerId": "1749428",
+      "workflow": ".github/workflows/publish-package-repository.yml"
+    }
+  ]
+}

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -249,6 +249,10 @@ export async function POST(request: Request) {
   // Whether this request is the one that made the branch, and so the only one
   // entitled to take it away again on the way out.
   let ownsBranch = false
+  // A branch that is there after a create whose answer never came back. It may
+  // be the one this request made, or a duplicate request's - nothing here can
+  // tell - so it is named in the error rather than removed.
+  let branchOfUnknownOwner = false
 
   try {
     try {
@@ -268,12 +272,15 @@ export async function POST(request: Request) {
         )
       }
       // Anything else may have failed on the way back rather than on the way
-      // out: GitHub made the branch and the answer never arrived. Ask whether
-      // the ref is there before concluding this request created nothing -
-      // otherwise the branch is left behind with no one willing to tidy it,
-      // and every later request for this run meets it as a 409.
+      // out: GitHub made the branch and the answer never arrived. A branch
+      // that is there now is either that one or a duplicate request's, and the
+      // two look exactly alike - both sit at main's tip under the one name
+      // this run can produce. Claiming it on a guess would mean deleting a
+      // sibling's branch while it is still uploading to it, leaving its pull
+      // request without a head; a branch nobody removes only costs a re-run.
+      // So: look, report, do not touch.
       try {
-        ownsBranch = await branchExists(branchName)
+        branchOfUnknownOwner = await branchExists(branchName)
       } catch (lookupError) {
         console.error('Trusted publishing: could not tell whether the branch was created', lookupError)
       }
@@ -376,21 +383,20 @@ export async function POST(request: Request) {
     // shared by every request for this run, and tidying away one that another
     // request is still building would break its pull request rather than clean
     // up after this one.
-    let strandedBranch = false
-    if (ownsBranch) {
-      strandedBranch = !(await deleteBranch(branchName))
-    }
+    const strandedBranch = ownsBranch
+      ? !(await deleteBranch(branchName))
+      : branchOfUnknownOwner
 
     const message = error instanceof Error ? error.message : 'Failed to create the pull request'
-    // A branch we could not take away outlives this request, and the name
-    // comes from the run, so every retry of this attempt will be turned away
-    // as "already in progress". Better to name the wreckage here than to let
-    // the workflow retry into a 409 it cannot read.
+    // A branch still standing outlives this request, and the name comes from
+    // the run attempt, so retrying this attempt only meets it again as a 409.
+    // Better to name it here than to let the workflow retry into that.
     return NextResponse.json(
       {
         error: strandedBranch
-          ? `${message}. The branch ${branchName} was left behind and could not be removed: ` +
-            're-run the workflow to publish, and delete that branch by hand.'
+          ? `${message}. The publish branch ${branchName} is still there: if no pull request ` +
+            'appears for this run, re-run the workflow - a retry of this attempt would land ' +
+            'on the same branch name.'
           : message,
       },
       { status: 500 },

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -1,12 +1,15 @@
 import { NextResponse } from 'next/server'
+import { randomUUID } from 'node:crypto'
 import AdmZip from 'adm-zip'
 import {
   branchExists,
+  branchesWithPrefix,
   createBranch,
   createPullRequest,
   deleteBranch,
   deleteFile,
   getFileSha,
+  openPullRequestForBranch,
   uploadFile,
 } from '@/app/lib/github'
 import { parseConfigLua } from '@/app/lib/packageParser'
@@ -240,47 +243,72 @@ export async function POST(request: Request) {
 
   // ---- 5. Same landing path as a website upload --------------------------
   const runUrl = `https://github.com/${claims.repository}/actions/runs/${claims.run_id}`
-  const branchName = `trusted-publish/${publisher.mpackage
+
+  // Everything but the last segment says which run this branch belongs to; the
+  // last segment says which request made it. Both halves earn their place: the
+  // shared part is how a second request for this run recognises the first, and
+  // the unique part is what makes ownership a fact rather than a guess, so a
+  // failed publish can clean up after itself without ever reaching for a
+  // branch some other request is still uploading to.
+  const branchPrefix = `trusted-publish/${publisher.mpackage
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-    .substring(0, 40)}-${metadata.version}-${claims.run_id}-${claims.run_attempt}`
+    .substring(0, 40)}-${metadata.version}-${claims.run_id}-${claims.run_attempt}-`
+  const branchName = `${branchPrefix}${randomUUID().slice(0, 8)}`
+
+  // Has a request for this same run already got a pull request open? Then this
+  // one is a duplicate call or a retry of a publish whose reply was lost, and
+  // the answer it wants is that pull request, not a second one beside it.
+  //
+  // Deliberately keyed on the pull request rather than on the branch: a branch
+  // with nothing open on it is either wreckage or a sibling seconds ahead of
+  // this request, and refusing on that would let one abandoned branch turn
+  // away every later publish for the run. Two simultaneous first calls can
+  // still slip through into two pull requests - a duplicate a human closes,
+  // which beats a publish path that jams shut.
+  try {
+    for (const sibling of await branchesWithPrefix(branchPrefix)) {
+      const open = await openPullRequestForBranch(sibling)
+      if (open) {
+        return NextResponse.json(
+          {
+            error: 'A publish for this workflow run is already open',
+            pullRequest: open.html_url,
+          },
+          { status: 409 },
+        )
+      }
+    }
+  } catch (error) {
+    // Only a courtesy check - a publish is not worth failing over it.
+    console.warn('Trusted publishing: could not look for an earlier publish of this run', error)
+  }
 
   // Whether this request is the one that made the branch, and so the only one
-  // entitled to take it away again on the way out.
+  // entitled to take it away again on the way out. The name carries a nonce no
+  // other request can produce, so a branch under it is ours by construction.
   let ownsBranch = false
-  // A branch that is there after a create whose answer never came back. It may
-  // be the one this request made, or a duplicate request's - nothing here can
-  // tell - so it is named in the error rather than removed.
-  let branchOfUnknownOwner = false
 
   try {
     try {
       await createBranch(branchName, 'main')
       ownsBranch = true
     } catch (error) {
-      // The name is derived from the run, so the only thing that already holds
-      // it is another request for this same run - a replayed token, or a
-      // duplicate call - which is partway through building it right now. That
-      // publish owns the branch and its pull request; say so and leave.
       const status =
         typeof error === 'object' && error && 'status' in error ? error.status : null
+      // Nothing else can be holding this name, so a refusal to create it is
+      // not a story about another publish - and a branch this request did not
+      // make is not a branch it may delete. Fail without touching anything.
       if (status === 422) {
-        return NextResponse.json(
-          { error: 'A publish for this workflow run is already in progress' },
-          { status: 409 },
-        )
+        throw error
       }
-      // Anything else may have failed on the way back rather than on the way
-      // out: GitHub made the branch and the answer never arrived. A branch
-      // that is there now is either that one or a duplicate request's, and the
-      // two look exactly alike - both sit at main's tip under the one name
-      // this run can produce. Claiming it on a guess would mean deleting a
-      // sibling's branch while it is still uploading to it, leaving its pull
-      // request without a head; a branch nobody removes only costs a re-run.
-      // So: look, report, do not touch.
+      // The call may have failed on the way back rather than on the way out:
+      // GitHub made the branch and the answer never arrived. The nonce settles
+      // whose it is - only this request could have asked for that name - so
+      // finding it there is enough to own it and tidy it away below.
       try {
-        branchOfUnknownOwner = await branchExists(branchName)
+        ownsBranch = await branchExists(branchName)
       } catch (lookupError) {
         console.error('Trusted publishing: could not tell whether the branch was created', lookupError)
       }
@@ -376,27 +404,19 @@ export async function POST(request: Request) {
     })
   } catch (error) {
     console.error('Trusted publishing: GitHub API error', error)
-    // Leave nothing half-done behind. A branch with commits but no pull request
-    // is invisible to every gate here, and the retry derives the same name from
-    // the same run, so it would collide with the wreckage instead of starting
-    // clean. Only ever the branch this request created, though: the name is
-    // shared by every request for this run, and tidying away one that another
-    // request is still building would break its pull request rather than clean
-    // up after this one.
-    const strandedBranch = ownsBranch
-      ? !(await deleteBranch(branchName))
-      : branchOfUnknownOwner
+    // Leave nothing half-done behind: a branch with commits but no pull
+    // request is invisible to every gate here. Only ever this request's own
+    // branch, which the nonce in the name guarantees.
+    const strandedBranch = ownsBranch && !(await deleteBranch(branchName))
 
     const message = error instanceof Error ? error.message : 'Failed to create the pull request'
-    // A branch still standing outlives this request, and the name comes from
-    // the run attempt, so retrying this attempt only meets it again as a 409.
-    // Better to name it here than to let the workflow retry into that.
+    // Nothing downstream depends on this branch going away - the next attempt
+    // picks its own name - but somebody has to be told it is sitting there.
     return NextResponse.json(
       {
         error: strandedBranch
-          ? `${message}. The publish branch ${branchName} is still there: if no pull request ` +
-            'appears for this run, re-run the workflow - a retry of this attempt would land ' +
-            'on the same branch name.'
+          ? `${message}. The publish branch ${branchName} could not be removed and needs ` +
+            'deleting by hand; publishing again is unaffected.'
           : message,
       },
       { status: 500 },

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import AdmZip from 'adm-zip'
 import {
+  branchExists,
   createBranch,
   createPullRequest,
   deleteBranch,
@@ -266,6 +267,16 @@ export async function POST(request: Request) {
           { status: 409 },
         )
       }
+      // Anything else may have failed on the way back rather than on the way
+      // out: GitHub made the branch and the answer never arrived. Ask whether
+      // the ref is there before concluding this request created nothing -
+      // otherwise the branch is left behind with no one willing to tidy it,
+      // and every later request for this run meets it as a 409.
+      try {
+        ownsBranch = await branchExists(branchName)
+      } catch (lookupError) {
+        console.error('Trusted publishing: could not tell whether the branch was created', lookupError)
+      }
       throw error
     }
 
@@ -364,13 +375,24 @@ export async function POST(request: Request) {
     // clean. Only ever the branch this request created, though: the name is
     // shared by every request for this run, and tidying away one that another
     // request is still building would break its pull request rather than clean
-    // up after this one. Best-effort - a branch that cannot be removed is not
-    // worth failing over, since the response is already an error.
+    // up after this one.
+    let strandedBranch = false
     if (ownsBranch) {
-      await deleteBranch(branchName)
+      strandedBranch = !(await deleteBranch(branchName))
     }
+
+    const message = error instanceof Error ? error.message : 'Failed to create the pull request'
+    // A branch we could not take away outlives this request, and the name
+    // comes from the run, so every retry of this attempt will be turned away
+    // as "already in progress". Better to name the wreckage here than to let
+    // the workflow retry into a 409 it cannot read.
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Failed to create the pull request' },
+      {
+        error: strandedBranch
+          ? `${message}. The branch ${branchName} was left behind and could not be removed: ` +
+            're-run the workflow to publish, and delete that branch by hand.'
+          : message,
+      },
       { status: 500 },
     )
   }

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -24,11 +24,12 @@ import {
 } from '@/app/lib/provenance'
 import {
   assertFilenameSane,
-  assertPackageMatches,
   authorise,
   loadRegistry,
+  publisherFor,
   PublisherError,
   REGISTRY_PATH,
+  type TrustedPublisher,
 } from '@/app/lib/trustedPublishers'
 
 /**
@@ -133,11 +134,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'This token has already been used' }, { status: 409 })
   }
 
-  // ---- 2. May they publish this package ---------------------------------
-  let publisher
+  // ---- 2. May this workflow publish anything ----------------------------
+  // Which package it is publishing is not known until config.lua has been
+  // read, so this settles only that the run is one the registry knows, and
+  // hands back every entry it may act for.
+  let authorised: TrustedPublisher[]
   try {
-    publisher = authorise(claims, await loadRegistry())
-    assertFilenameSane(publisher.filename)
+    authorised = authorise(claims, await loadRegistry())
   } catch (error) {
     if (error instanceof PublisherError) {
       return NextResponse.json({ error: error.message }, { status: 403 })
@@ -202,8 +205,12 @@ export async function POST(request: Request) {
     )
   }
 
+  // Which of the authorised entries this is, and whether the run satisfies the
+  // conditions that entry puts on it.
+  let publisher: TrustedPublisher
   try {
-    assertPackageMatches(publisher, metadata.mpackage)
+    publisher = publisherFor(claims, authorised, metadata.mpackage)
+    assertFilenameSane(publisher.filename)
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof PublisherError ? error.message : 'Package mismatch' },

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -1,0 +1,338 @@
+import { NextResponse } from 'next/server'
+import AdmZip from 'adm-zip'
+import { createBranch, uploadFile, createPullRequest, getFileSha, deleteFile } from '@/app/lib/github'
+import { parseConfigLua } from '@/app/lib/packageParser'
+import { MAX_METADATA_BYTES, readEntryWithin } from '@/app/lib/packageArchive'
+import { fetchRepositoryPackages } from '@/app/lib/packages'
+import { bearerToken, rememberToken, verifyActionsToken, TokenError, PUBLISH_AUDIENCE } from '@/app/lib/oidc'
+import {
+  provenancePathFor,
+  serialiseRecord,
+  sha256,
+  type ProvenanceRecord,
+} from '@/app/lib/provenance'
+import {
+  assertFilenameSane,
+  assertPackageMatches,
+  authorise,
+  loadRegistry,
+  PublisherError,
+  REGISTRY_PATH,
+} from '@/app/lib/trustedPublishers'
+
+/**
+ * Trusted publishing: a GitHub Actions workflow submits a new version of its
+ * own package with nothing but the OIDC token GitHub minted for that run.
+ *
+ * The package author stores no credential anywhere. What authorises the
+ * publish is an entry in trusted-publishers.json naming their repository and
+ * the one workflow file allowed to act for the package - a file that only
+ * changes through a reviewed pull request.
+ *
+ * The outcome is deliberately the same as a website upload: a branch and a pull
+ * request opened by the machine account. Every existing gate - the mpackage
+ * validation workflow, the review bot, auto-merge - still applies, so this
+ * endpoint changes who may *ask*, never what may land.
+ */
+
+/** Refuse an archive larger than the website's own upload ceiling. */
+const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024
+
+/** The artifact must be a release asset of the very repository that was authenticated. */
+function assertArtifactBelongsToRun(artifactUrl: string, repository: string): URL {
+  let url: URL
+  try {
+    url = new URL(artifactUrl)
+  } catch {
+    throw new PublisherError('artifactUrl is not a valid URL')
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new PublisherError('artifactUrl must be https')
+  }
+  if (url.hostname !== 'github.com') {
+    throw new PublisherError('artifactUrl must be a github.com release asset URL')
+  }
+
+  // https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>
+  const parts = url.pathname.split('/').filter(Boolean)
+  const looksRight =
+    parts.length >= 6 && parts[2] === 'releases' && parts[3] === 'download'
+  if (!looksRight) {
+    throw new PublisherError(
+      'artifactUrl must be a release asset: https://github.com/<owner>/<repo>/releases/download/<tag>/<file>',
+    )
+  }
+
+  const artifactRepo = `${parts[0]}/${parts[1]}`
+  if (artifactRepo.toLowerCase() !== repository.toLowerCase()) {
+    throw new PublisherError(
+      `artifactUrl points at ${artifactRepo}, but the token was issued to ${repository}`,
+    )
+  }
+
+  return url
+}
+
+async function downloadArtifact(url: URL): Promise<Buffer> {
+  const response = await fetch(url, { redirect: 'follow' })
+  if (!response.ok) {
+    throw new PublisherError(`could not download the artifact (HTTP ${response.status})`)
+  }
+
+  const declared = Number(response.headers.get('content-length') ?? '')
+  if (Number.isFinite(declared) && declared > MAX_ARCHIVE_BYTES) {
+    throw new PublisherError(`artifact is larger than ${MAX_ARCHIVE_BYTES} bytes`)
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer())
+  // Re-check: content-length may have been absent or wrong.
+  if (buffer.length > MAX_ARCHIVE_BYTES) {
+    throw new PublisherError(`artifact is larger than ${MAX_ARCHIVE_BYTES} bytes`)
+  }
+  if (buffer.length === 0) {
+    throw new PublisherError('the artifact is empty')
+  }
+  return buffer
+}
+
+export async function POST(request: Request) {
+  // ---- 1. Who is calling ------------------------------------------------
+  const token = bearerToken(request)
+  if (!token) {
+    return NextResponse.json(
+      {
+        error:
+          'Missing bearer token. Request a GitHub Actions OIDC token with ' +
+          `audience "${PUBLISH_AUDIENCE}" and send it as "Authorization: Bearer <token>".`,
+      },
+      { status: 401 },
+    )
+  }
+
+  let claims
+  try {
+    claims = await verifyActionsToken(token)
+  } catch (error) {
+    const message = error instanceof TokenError ? error.message : 'OIDC token rejected'
+    return NextResponse.json({ error: message }, { status: 401 })
+  }
+
+  if (!rememberToken(claims)) {
+    return NextResponse.json({ error: 'This token has already been used' }, { status: 409 })
+  }
+
+  // ---- 2. May they publish this package ---------------------------------
+  let publisher
+  try {
+    publisher = authorise(claims, await loadRegistry())
+    assertFilenameSane(publisher.filename)
+  } catch (error) {
+    if (error instanceof PublisherError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+    console.error('Trusted publishing: registry unavailable', error)
+    return NextResponse.json(
+      { error: `Could not read ${REGISTRY_PATH}` },
+      { status: 503 },
+    )
+  }
+
+  // ---- 3. Fetch and inspect the artifact --------------------------------
+  let body: { artifactUrl?: unknown }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 })
+  }
+
+  if (typeof body.artifactUrl !== 'string' || !body.artifactUrl) {
+    return NextResponse.json({ error: 'Missing "artifactUrl"' }, { status: 400 })
+  }
+
+  let fileBuffer: Buffer
+  try {
+    const url = assertArtifactBelongsToRun(body.artifactUrl, claims.repository)
+    fileBuffer = await downloadArtifact(url)
+  } catch (error) {
+    if (error instanceof PublisherError) {
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+    console.error('Trusted publishing: artifact download failed', error)
+    return NextResponse.json({ error: 'Could not download the artifact' }, { status: 502 })
+  }
+
+  let metadata
+  try {
+    const zip = new AdmZip(fileBuffer)
+    const configEntry = zip.getEntry('config.lua')
+    if (!configEntry) {
+      return NextResponse.json({ error: 'Missing config.lua' }, { status: 400 })
+    }
+    const config = readEntryWithin(configEntry, MAX_METADATA_BYTES)
+    if (!config) {
+      return NextResponse.json(
+        { error: 'config.lua is too large to be a Mudlet package config' },
+        { status: 400 },
+      )
+    }
+    metadata = parseConfigLua(config.toString('utf8'))
+  } catch (error) {
+    console.error('Trusted publishing: archive unreadable', error)
+    return NextResponse.json({ error: 'The artifact is not a readable zip archive' }, { status: 400 })
+  }
+
+  const missing = (['mpackage', 'title', 'version', 'created', 'author', 'description'] as const)
+    .filter((field) => !metadata[field])
+  if (missing.length) {
+    return NextResponse.json(
+      { error: `config.lua is missing: ${missing.join(', ')}` },
+      { status: 400 },
+    )
+  }
+
+  try {
+    assertPackageMatches(publisher, metadata.mpackage)
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof PublisherError ? error.message : 'Package mismatch' },
+      { status: 403 },
+    )
+  }
+
+  // ---- 4. Do not publish over somebody else's package --------------------
+  // The registry already binds this workflow to this package name, but the
+  // index is what the world reads: if a package of this name is already there
+  // under a different author, the registry entry and reality disagree and a
+  // human needs to look rather than one of them silently winning.
+  const filename = publisher.filename
+  let existingFilename: string | null = null
+  try {
+    const packages = await fetchRepositoryPackages()
+    const existing = packages.find(
+      (pkg) => (pkg.mpackage || '').trim().toLowerCase() === publisher.mpackage.trim().toLowerCase(),
+    )
+    if (existing) {
+      if ((existing.author || '').trim().toLowerCase() !== (metadata.author || '').trim().toLowerCase()) {
+        return NextResponse.json(
+          {
+            error:
+              `"${publisher.mpackage}" is published by "${existing.author}", but this ` +
+              `upload is authored by "${metadata.author}"`,
+          },
+          { status: 409 },
+        )
+      }
+      existingFilename = existing.filename
+    }
+  } catch (error) {
+    console.error('Trusted publishing: could not read the package index', error)
+    return NextResponse.json({ error: 'Could not read the package index' }, { status: 503 })
+  }
+
+  // ---- 5. Same landing path as a website upload --------------------------
+  const runUrl = `https://github.com/${claims.repository}/actions/runs/${claims.run_id}`
+  const branchName = `trusted-publish/${publisher.mpackage
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .substring(0, 40)}-${metadata.version}-${claims.run_id}-${claims.run_attempt}`
+
+  try {
+    await createBranch(branchName, 'main')
+
+    // A renamed file would otherwise leave the old one behind as a second copy.
+    if (existingFilename && existingFilename !== filename) {
+      const oldSha = await getFileSha(`packages/${existingFilename}`)
+      if (oldSha) {
+        await deleteFile(
+          `packages/${existingFilename}`,
+          `Delete old version: ${existingFilename}`,
+          oldSha,
+          branchName,
+        )
+      }
+    }
+
+    await uploadFile(
+      `packages/${filename}`,
+      fileBuffer.toString('base64'),
+      branchName,
+      existingFilename ? `Update package: ${filename}` : `Add package: ${filename}`,
+    )
+
+    // Pin the provenance to these exact bytes. Anything that replaces the
+    // archive later - a website upload, a hand-written pull request, a direct
+    // commit - leaves this digest describing a file that is no longer there,
+    // and the site stops showing the package as CI-published. See provenance.ts.
+    const record: ProvenanceRecord = {
+      filename,
+      mpackage: publisher.mpackage,
+      sha256: sha256(fileBuffer),
+      version: metadata.version as string,
+      repository: claims.repository,
+      repositoryId: claims.repository_id,
+      workflow: publisher.workflow,
+      ref: claims.ref,
+      commit: claims.sha,
+      runId: claims.run_id,
+      publishedAt: new Date().toISOString(),
+    }
+
+    // One file per package: two packages publishing at the same time would
+    // otherwise be editing one shared file on two branches cut from the same
+    // commit, and whichever merged second would land in conflict.
+    const provenancePath = provenancePathFor(filename)
+    await uploadFile(
+      provenancePath,
+      Buffer.from(serialiseRecord(record), 'utf8').toString('base64'),
+      branchName,
+      `Record provenance for ${filename} ${metadata.version}`,
+      (await getFileSha(provenancePath)) ?? undefined,
+    )
+
+    // A renamed package must not leave its old record behind vouching for a
+    // file that is no longer published.
+    if (existingFilename && existingFilename !== filename) {
+      const stalePath = provenancePathFor(existingFilename)
+      const staleSha = await getFileSha(stalePath)
+      if (staleSha) {
+        await deleteFile(stalePath, `Remove provenance for ${existingFilename}`, staleSha, branchName)
+      }
+    }
+
+    const pr = await createPullRequest(
+      branchName,
+      `${existingFilename ? 'Update' : 'Add'} package: ${filename} (${metadata.version})`,
+      [
+        `Published by a trusted workflow - no human uploaded this.`,
+        ``,
+        `- Package: ${metadata.mpackage}`,
+        `- Version: ${metadata.version}`,
+        `- Author: ${metadata.author}`,
+        `- Repository: [${claims.repository}](https://github.com/${claims.repository})`,
+        `- Workflow: \`${claims.job_workflow_ref}\``,
+        `- Commit: [\`${claims.sha.slice(0, 7)}\`](https://github.com/${claims.repository}/commit/${claims.sha})`,
+        `- Run: ${runUrl}`,
+        ``,
+        `Authorised by the \`${publisher.mpackage}\` entry in [\`${REGISTRY_PATH}\`](../blob/main/${REGISTRY_PATH}).`,
+        ``,
+        `---`,
+        metadata.description,
+      ].join('\n'),
+    )
+
+    return NextResponse.json({
+      success: true,
+      pullRequest: pr.data.html_url,
+      filename,
+      version: metadata.version,
+    })
+  } catch (error) {
+    console.error('Trusted publishing: GitHub API error', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create the pull request' },
+      { status: 500 },
+    )
+  }
+}

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -245,8 +245,29 @@ export async function POST(request: Request) {
     .replace(/^-+|-+$/g, '')
     .substring(0, 40)}-${metadata.version}-${claims.run_id}-${claims.run_attempt}`
 
+  // Whether this request is the one that made the branch, and so the only one
+  // entitled to take it away again on the way out.
+  let ownsBranch = false
+
   try {
-    await createBranch(branchName, 'main')
+    try {
+      await createBranch(branchName, 'main')
+      ownsBranch = true
+    } catch (error) {
+      // The name is derived from the run, so the only thing that already holds
+      // it is another request for this same run - a replayed token, or a
+      // duplicate call - which is partway through building it right now. That
+      // publish owns the branch and its pull request; say so and leave.
+      const status =
+        typeof error === 'object' && error && 'status' in error ? error.status : null
+      if (status === 422) {
+        return NextResponse.json(
+          { error: 'A publish for this workflow run is already in progress' },
+          { status: 409 },
+        )
+      }
+      throw error
+    }
 
     // A renamed file would otherwise leave the old one behind as a second copy.
     if (existingFilename && existingFilename !== filename) {
@@ -340,9 +361,14 @@ export async function POST(request: Request) {
     // Leave nothing half-done behind. A branch with commits but no pull request
     // is invisible to every gate here, and the retry derives the same name from
     // the same run, so it would collide with the wreckage instead of starting
-    // clean. Best-effort: a branch that cannot be removed is not worth failing
-    // the response over, since the response is already an error.
-    await deleteBranch(branchName)
+    // clean. Only ever the branch this request created, though: the name is
+    // shared by every request for this run, and tidying away one that another
+    // request is still building would break its pull request rather than clean
+    // up after this one. Best-effort - a branch that cannot be removed is not
+    // worth failing over, since the response is already an error.
+    if (ownsBranch) {
+      await deleteBranch(branchName)
+    }
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Failed to create the pull request' },
       { status: 500 },

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -422,7 +422,15 @@ export async function POST(request: Request) {
     // A 4xx is GitHub having read the request and refused it, so whatever it
     // asked for did not happen. A timeout, a dropped connection, a 5xx: those
     // may have happened and lost the answer on the way back.
-    const refusedOutright = status !== null && status >= 400 && status < 500
+    //
+    // 422 is the exception, and the reason it is spelled out. It is what
+    // opening a pull request answers once one is already open - so it is the
+    // shape a *succeeded* create takes when the reply is lost and octokit's
+    // retry plugin asks a second time. Reading it as a refusal would have this
+    // request delete the branch under the pull request it just opened, which
+    // closes it.
+    const refusedOutright =
+      status !== null && status >= 400 && status < 500 && status !== 422
 
     // Opening the pull request is the last thing this request does, so once it
     // has been asked for, no failure short of an outright refusal says it was

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -15,7 +15,14 @@ import {
 import { parseConfigLua } from '@/app/lib/packageParser'
 import { MAX_METADATA_BYTES, readEntryWithin } from '@/app/lib/packageArchive'
 import { fetchRepositoryPackages } from '@/app/lib/packages'
-import { bearerToken, rememberToken, verifyActionsToken, TokenError, PUBLISH_AUDIENCE } from '@/app/lib/oidc'
+import {
+  bearerToken,
+  rememberToken,
+  verifyActionsToken,
+  TokenError,
+  PUBLISH_AUDIENCE,
+  type ActionsClaims,
+} from '@/app/lib/oidc'
 import {
   provenancePathFor,
   serialiseRecord,
@@ -50,8 +57,19 @@ import {
 /** Refuse an archive larger than the website's own upload ceiling. */
 const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024
 
-/** The artifact must be a release asset of the very repository that was authenticated. */
-function assertArtifactBelongsToRun(artifactUrl: string, repository: string): URL {
+/**
+ * The artifact must be a release asset of the very repository that was
+ * authenticated, and - when the run is on a tag - of that tag's own release.
+ *
+ * The tag is what ties the archive to the run rather than merely to the
+ * repository. A run triggered by a release publishes that release's assets, so
+ * pinning it costs nothing and closes the gap where a run on today's code
+ * submits an asset from a release of two years ago. Nothing pins a run on a
+ * branch, which is why the provenance panel says the archive was published by
+ * this run rather than built by it.
+ */
+function assertArtifactBelongsToRun(artifactUrl: string, claims: ActionsClaims): URL {
+  const repository = claims.repository
   let url: URL
   try {
     url = new URL(artifactUrl)
@@ -83,6 +101,21 @@ function assertArtifactBelongsToRun(artifactUrl: string, repository: string): UR
     )
   }
 
+  // Everything between .../download/ and the file name is the tag, which may
+  // itself contain slashes.
+  const tag = claims.ref.startsWith('refs/tags/') ? claims.ref.slice('refs/tags/'.length) : null
+  if (tag) {
+    const assetTag = parts
+      .slice(4, -1)
+      .map((segment) => decodeURIComponent(segment))
+      .join('/')
+    if (assetTag !== tag) {
+      throw new PublisherError(
+        `artifactUrl is an asset of the ${assetTag} release, but this run is on ${tag}`,
+      )
+    }
+  }
+
   return url
 }
 
@@ -91,21 +124,42 @@ async function downloadArtifact(url: URL): Promise<Buffer> {
   if (!response.ok) {
     throw new PublisherError(`could not download the artifact (HTTP ${response.status})`)
   }
+  if (!response.body) {
+    throw new PublisherError('the artifact download returned no content')
+  }
 
-  const declared = Number(response.headers.get('content-length') ?? '')
+  // A header worth believing saves the download entirely. It is only ever a
+  // shortcut: an absent or nonsensical one - a chunked response has none - says
+  // nothing about the size, so it must not be read as saying the size is fine.
+  const declared = Number(response.headers.get('content-length'))
   if (Number.isFinite(declared) && declared > MAX_ARCHIVE_BYTES) {
     throw new PublisherError(`artifact is larger than ${MAX_ARCHIVE_BYTES} bytes`)
   }
 
-  const buffer = Buffer.from(await response.arrayBuffer())
-  // Re-check: content-length may have been absent or wrong.
-  if (buffer.length > MAX_ARCHIVE_BYTES) {
-    throw new PublisherError(`artifact is larger than ${MAX_ARCHIVE_BYTES} bytes`)
+  // So the ceiling is enforced on the bytes as they arrive, and a body that
+  // runs past it is dropped mid-flight rather than held whole in memory first.
+  const reader = response.body.getReader()
+  const chunks: Buffer[] = []
+  let received = 0
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      received += value.byteLength
+      if (received > MAX_ARCHIVE_BYTES) {
+        await reader.cancel().catch(() => {})
+        throw new PublisherError(`artifact is larger than ${MAX_ARCHIVE_BYTES} bytes`)
+      }
+      chunks.push(Buffer.from(value))
+    }
+  } finally {
+    reader.releaseLock()
   }
-  if (buffer.length === 0) {
+
+  if (received === 0) {
     throw new PublisherError('the artifact is empty')
   }
-  return buffer
+  return Buffer.concat(chunks)
 }
 
 export async function POST(request: Request) {
@@ -166,7 +220,7 @@ export async function POST(request: Request) {
 
   let fileBuffer: Buffer
   try {
-    const url = assertArtifactBelongsToRun(body.artifactUrl, claims.repository)
+    const url = assertArtifactBelongsToRun(body.artifactUrl, claims)
     fileBuffer = await downloadArtifact(url)
   } catch (error) {
     if (error instanceof PublisherError) {
@@ -224,14 +278,35 @@ export async function POST(request: Request) {
   // under a different author, the registry entry and reality disagree and a
   // human needs to look rather than one of them silently winning.
   const filename = publisher.filename
+  const sameText = (a: string | null | undefined, b: string | null | undefined) =>
+    (a || '').trim().toLowerCase() === (b || '').trim().toLowerCase()
   let existingFilename: string | null = null
   try {
     const packages = await fetchRepositoryPackages()
-    const existing = packages.find(
-      (pkg) => (pkg.mpackage || '').trim().toLowerCase() === publisher.mpackage.trim().toLowerCase(),
+
+    // Two entries may name one file, and the registry alone cannot tell: each
+    // is checked against its own ids and its own package name, so an entry
+    // whose filename happens to be somebody else's would authorise a write
+    // straight over their archive. What settles it is the index - if
+    // packages/<filename> is some other package's file, this publish is not
+    // the one entitled to it.
+    const occupied = packages.find(
+      (pkg) => sameText(pkg.filename, filename) && !sameText(pkg.mpackage, publisher.mpackage),
     )
+    if (occupied) {
+      return NextResponse.json(
+        {
+          error:
+            `packages/${filename} is the file of "${occupied.mpackage}", so "${publisher.mpackage}" ` +
+            `cannot be published to it. The filename in ${REGISTRY_PATH} needs changing.`,
+        },
+        { status: 409 },
+      )
+    }
+
+    const existing = packages.find((pkg) => sameText(pkg.mpackage, publisher.mpackage))
     if (existing) {
-      if ((existing.author || '').trim().toLowerCase() !== (metadata.author || '').trim().toLowerCase()) {
+      if (!sameText(existing.author, metadata.author)) {
         return NextResponse.json(
           {
             error:
@@ -257,11 +332,20 @@ export async function POST(request: Request) {
   // the unique part is what makes ownership a fact rather than a guess, so a
   // failed publish can clean up after itself without ever reaching for a
   // branch some other request is still uploading to.
-  const branchPrefix = `trusted-publish/${publisher.mpackage
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .substring(0, 40)}-${metadata.version}-${claims.run_id}-${claims.run_attempt}-`
+  // Both halves are reduced to what a git ref may hold. config.lua is the
+  // package author's file, and a version reading "1.0 beta", "2.0~rc1" or
+  // "v1.0^2" - or, since the parser accepts a [[...]] literal, one carrying a
+  // newline - would otherwise reach GitHub as an invalid ref name and come back
+  // as a 422 that never mentions the version.
+  const slug = (value: string) =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .substring(0, 40)
+  const branchPrefix =
+    `trusted-publish/${slug(publisher.mpackage)}-${slug(String(metadata.version))}-` +
+    `${claims.run_id}-${claims.run_attempt}-`
   const branchName = `${branchPrefix}${randomUUID().slice(0, 8)}`
 
   // Has a request for this same run already got a pull request open? Then this

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -404,6 +404,39 @@ export async function POST(request: Request) {
     })
   } catch (error) {
     console.error('Trusted publishing: GitHub API error', error)
+
+    // Opening the pull request is the last thing this request does, so one
+    // standing open on this branch means the publish landed and only the
+    // answer was lost on the way back. That is a success wearing an error's
+    // clothes: report it as the success it is, and - the point of looking
+    // before the cleanup below - do not delete the branch out from under a
+    // pull request that is already waiting for review.
+    if (ownsBranch) {
+      try {
+        const opened = await openPullRequestForBranch(branchName)
+        if (opened) {
+          return NextResponse.json({
+            success: true,
+            pullRequest: opened.html_url,
+            filename,
+            version: metadata.version,
+          })
+        }
+      } catch (lookupError) {
+        console.error('Trusted publishing: could not tell whether a pull request was opened', lookupError)
+        // Unknown is not "no". Leave the branch: an orphan costs a stray
+        // branch, deleting a live pull request's head costs the publish.
+        return NextResponse.json(
+          {
+            error:
+              (error instanceof Error ? error.message : 'Failed to create the pull request') +
+              `. Check whether a pull request was opened from ${branchName} before publishing again.`,
+          },
+          { status: 500 },
+        )
+      }
+    }
+
     // Leave nothing half-done behind: a branch with commits but no pull
     // request is invisible to every gate here. Only ever this request's own
     // branch, which the nonce in the name guarantees.

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from 'next/server'
 import AdmZip from 'adm-zip'
-import { createBranch, uploadFile, createPullRequest, getFileSha, deleteFile } from '@/app/lib/github'
+import {
+  createBranch,
+  createPullRequest,
+  deleteBranch,
+  deleteFile,
+  getFileSha,
+  uploadFile,
+} from '@/app/lib/github'
 import { parseConfigLua } from '@/app/lib/packageParser'
 import { MAX_METADATA_BYTES, readEntryWithin } from '@/app/lib/packageArchive'
 import { fetchRepositoryPackages } from '@/app/lib/packages'
@@ -330,6 +337,12 @@ export async function POST(request: Request) {
     })
   } catch (error) {
     console.error('Trusted publishing: GitHub API error', error)
+    // Leave nothing half-done behind. A branch with commits but no pull request
+    // is invisible to every gate here, and the retry derives the same name from
+    // the same run, so it would collide with the wreckage instead of starting
+    // clean. Best-effort: a branch that cannot be removed is not worth failing
+    // the response over, since the response is already an error.
+    await deleteBranch(branchName)
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Failed to create the pull request' },
       { status: 500 },

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -320,7 +320,7 @@ export async function POST(request: Request) {
 
     // A renamed file would otherwise leave the old one behind as a second copy.
     if (existingFilename && existingFilename !== filename) {
-      const oldSha = await getFileSha(`packages/${existingFilename}`)
+      const oldSha = await getFileSha(`packages/${existingFilename}`, branchName)
       if (oldSha) {
         await deleteFile(
           `packages/${existingFilename}`,
@@ -331,11 +331,18 @@ export async function POST(request: Request) {
       }
     }
 
+    // Every publish after the first writes over an archive that is already on
+    // the branch, and GitHub refuses that unless it is told which blob is being
+    // replaced. Asked of the branch rather than worked out from the index: the
+    // index describes the last build of the site, while this has to describe
+    // the tree the commit lands on.
+    const packagePath = `packages/${filename}`
     await uploadFile(
-      `packages/${filename}`,
+      packagePath,
       fileBuffer.toString('base64'),
       branchName,
       existingFilename ? `Update package: ${filename}` : `Add package: ${filename}`,
+      (await getFileSha(packagePath, branchName)) ?? undefined,
     )
 
     // Pin the provenance to these exact bytes. Anything that replaces the
@@ -365,14 +372,14 @@ export async function POST(request: Request) {
       Buffer.from(serialiseRecord(record), 'utf8').toString('base64'),
       branchName,
       `Record provenance for ${filename} ${metadata.version}`,
-      (await getFileSha(provenancePath)) ?? undefined,
+      (await getFileSha(provenancePath, branchName)) ?? undefined,
     )
 
     // A renamed package must not leave its old record behind vouching for a
     // file that is no longer published.
     if (existingFilename && existingFilename !== filename) {
       const stalePath = provenancePathFor(existingFilename)
-      const staleSha = await getFileSha(stalePath)
+      const staleSha = await getFileSha(stalePath, branchName)
       if (staleSha) {
         await deleteFile(stalePath, `Remove provenance for ${existingFilename}`, staleSha, branchName)
       }

--- a/upload-site/app/api/publish/route.ts
+++ b/upload-site/app/api/publish/route.ts
@@ -289,6 +289,9 @@ export async function POST(request: Request) {
   // entitled to take it away again on the way out. The name carries a nonce no
   // other request can produce, so a branch under it is ours by construction.
   let ownsBranch = false
+  // Whether the pull request was asked for. Once it has been, no failure can
+  // be read as proof that it was not opened.
+  let pullRequestAttempted = false
 
   try {
     try {
@@ -375,6 +378,8 @@ export async function POST(request: Request) {
       }
     }
 
+    // From here on a failure cannot be read as "no pull request was opened".
+    pullRequestAttempted = true
     const pr = await createPullRequest(
       branchName,
       `${existingFilename ? 'Update' : 'Add'} package: ${filename} (${metadata.version})`,
@@ -404,45 +409,55 @@ export async function POST(request: Request) {
     })
   } catch (error) {
     console.error('Trusted publishing: GitHub API error', error)
+    const message = error instanceof Error ? error.message : 'Failed to create the pull request'
+    const status =
+      typeof error === 'object' && error && 'status' in error ? Number(error.status) : null
+    // A 4xx is GitHub having read the request and refused it, so whatever it
+    // asked for did not happen. A timeout, a dropped connection, a 5xx: those
+    // may have happened and lost the answer on the way back.
+    const refusedOutright = status !== null && status >= 400 && status < 500
 
-    // Opening the pull request is the last thing this request does, so one
-    // standing open on this branch means the publish landed and only the
-    // answer was lost on the way back. That is a success wearing an error's
-    // clothes: report it as the success it is, and - the point of looking
-    // before the cleanup below - do not delete the branch out from under a
-    // pull request that is already waiting for review.
-    if (ownsBranch) {
+    // Opening the pull request is the last thing this request does, so once it
+    // has been asked for, no failure short of an outright refusal says it was
+    // not opened - and the branch must not be touched on a guess, because
+    // deleting the head of an open pull request closes it.
+    if (ownsBranch && pullRequestAttempted && !refusedOutright) {
+      let opened = null
       try {
-        const opened = await openPullRequestForBranch(branchName)
-        if (opened) {
-          return NextResponse.json({
-            success: true,
-            pullRequest: opened.html_url,
-            filename,
-            version: metadata.version,
-          })
-        }
+        opened = await openPullRequestForBranch(branchName)
       } catch (lookupError) {
         console.error('Trusted publishing: could not tell whether a pull request was opened', lookupError)
-        // Unknown is not "no". Leave the branch: an orphan costs a stray
-        // branch, deleting a live pull request's head costs the publish.
-        return NextResponse.json(
-          {
-            error:
-              (error instanceof Error ? error.message : 'Failed to create the pull request') +
-              `. Check whether a pull request was opened from ${branchName} before publishing again.`,
-          },
-          { status: 500 },
-        )
       }
+      // Found: a success wearing an error's clothes. The publish landed and
+      // only the reply went missing, so hand back what the caller came for.
+      if (opened) {
+        return NextResponse.json({
+          success: true,
+          pullRequest: opened.html_url,
+          filename,
+          version: metadata.version,
+        })
+      }
+      // Not found is not proof either: a pull request seconds old can be
+      // missing from a listing that has not caught up yet. Every reading of
+      // silence here is a guess, and the cheap guess is the branch - an orphan
+      // costs a stray ref, closing a live pull request costs the publish.
+      return NextResponse.json(
+        {
+          error:
+            `${message}. A pull request may have been opened from ${branchName}: check for ` +
+            'one before publishing again, and delete that branch if there is none.',
+        },
+        { status: 500 },
+      )
     }
 
-    // Leave nothing half-done behind: a branch with commits but no pull
-    // request is invisible to every gate here. Only ever this request's own
-    // branch, which the nonce in the name guarantees.
+    // Otherwise the pull request was never reached, or was refused outright,
+    // so the branch carries commits nothing will ever review. Leave nothing
+    // half-done behind - and only ever this request's own branch, which the
+    // nonce in the name guarantees.
     const strandedBranch = ownsBranch && !(await deleteBranch(branchName))
 
-    const message = error instanceof Error ? error.message : 'Failed to create the pull request'
     // Nothing downstream depends on this branch going away - the next attempt
     // picks its own name - but somebody has to be told it is sitting there.
     return NextResponse.json(

--- a/upload-site/app/components/TrustedPublisher.tsx
+++ b/upload-site/app/components/TrustedPublisher.tsx
@@ -11,8 +11,11 @@ import { formatDate } from '@/app/lib/urls'
  * against the file being offered rather than taken on trust. Replace the file
  * by any other route and this panel stops appearing.
  *
- * The panel therefore states only what was verified: the repository, the
- * workflow file, and the commit it was built from.
+ * The panel therefore states only what was verified. What the record proves is
+ * that these bytes were submitted by that run, not that the run compiled them:
+ * a release asset can be attached to a release by hand, and only a run on a tag
+ * is pinned to the release it publishes. So the wording is "published from",
+ * and the commit is named as the one the run was on.
  */
 export function TrustedPublisherPanel({ record }: { record: ProvenanceRecord }) {
   const repoUrl = `https://github.com/${record.repository}`
@@ -26,12 +29,12 @@ export function TrustedPublisherPanel({ record }: { record: ProvenanceRecord }) 
         <svg viewBox="0 0 16 16" aria-hidden="true" className="h-4 w-4 shrink-0 fill-success">
           <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0Zm3.78 5.97a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L4.22 9.03a.75.75 0 1 1 1.06-1.06L7 9.69l3.72-3.72a.75.75 0 0 1 1.06 0Z" />
         </svg>
-        Built and published from source
+        Published from source by CI
       </h2>
 
       <p className="mt-2 text-sm text-muted">
-        This exact file was uploaded by a GitHub Actions run in the repository below,
-        which proves where it was built. It is not a file anyone uploaded by hand.
+        This exact file was submitted by a GitHub Actions run in the repository below,
+        which proves where it came from. It is not a file anyone uploaded by hand.
       </p>
 
       <dl className="mt-3 flex flex-wrap gap-x-8 gap-y-3 text-sm">
@@ -67,7 +70,7 @@ export function TrustedPublisherPanel({ record }: { record: ProvenanceRecord }) 
         </div>
 
         <div className="min-w-0">
-          <dt className="text-xs uppercase tracking-wide text-muted">Built from</dt>
+          <dt className="text-xs uppercase tracking-wide text-muted">Published from</dt>
           <dd className="mt-0.5">
             <a
               href={`${repoUrl}/commit/${record.commit}`}

--- a/upload-site/app/components/TrustedPublisher.tsx
+++ b/upload-site/app/components/TrustedPublisher.tsx
@@ -1,0 +1,92 @@
+import type { ProvenanceRecord } from '@/app/lib/provenance'
+import { formatDate } from '@/app/lib/urls'
+
+/**
+ * Provenance for a package whose current archive was published from CI.
+ *
+ * What makes this worth showing: for most packages all anyone can see is that
+ * somebody uploaded a file. Here the archive was submitted by a GitHub Actions
+ * run in a named repository, proven by a token GitHub signed for that run - and
+ * the record is pinned to the digest of these exact bytes, so it is checked
+ * against the file being offered rather than taken on trust. Replace the file
+ * by any other route and this panel stops appearing.
+ *
+ * The panel therefore states only what was verified: the repository, the
+ * workflow file, and the commit it was built from.
+ */
+export function TrustedPublisherPanel({ record }: { record: ProvenanceRecord }) {
+  const repoUrl = `https://github.com/${record.repository}`
+  const workflowUrl = `${repoUrl}/blob/${record.commit}/${record.workflow}`
+  const workflowName = record.workflow.split('/').pop() ?? record.workflow
+  const published = formatDate(record.publishedAt)
+
+  return (
+    <section className="mt-8 rounded-xl border border-border bg-surface-muted p-4">
+      <h2 className="flex items-center gap-2 text-sm font-semibold">
+        <svg viewBox="0 0 16 16" aria-hidden="true" className="h-4 w-4 shrink-0 fill-success">
+          <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0Zm3.78 5.97a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L4.22 9.03a.75.75 0 1 1 1.06-1.06L7 9.69l3.72-3.72a.75.75 0 0 1 1.06 0Z" />
+        </svg>
+        Built and published from source
+      </h2>
+
+      <p className="mt-2 text-sm text-muted">
+        This exact file was uploaded by a GitHub Actions run in the repository below,
+        which proves where it was built. It is not a file anyone uploaded by hand.
+      </p>
+
+      <dl className="mt-3 flex flex-wrap gap-x-8 gap-y-3 text-sm">
+        <div className="min-w-0">
+          <dt className="text-xs uppercase tracking-wide text-muted">Repository</dt>
+          <dd className="mt-0.5">
+            <a
+              href={repoUrl}
+              className="inline-flex items-center gap-1.5 font-medium text-accent hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <svg viewBox="0 0 16 16" aria-hidden="true" className="h-4 w-4 shrink-0 fill-current">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+              </svg>
+              {record.repository}
+            </a>
+          </dd>
+        </div>
+
+        <div className="min-w-0">
+          <dt className="text-xs uppercase tracking-wide text-muted">Workflow</dt>
+          <dd className="mt-0.5">
+            <a
+              href={workflowUrl}
+              className="font-mono text-[0.8125rem] font-medium text-accent hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {workflowName}
+            </a>
+          </dd>
+        </div>
+
+        <div className="min-w-0">
+          <dt className="text-xs uppercase tracking-wide text-muted">Built from</dt>
+          <dd className="mt-0.5">
+            <a
+              href={`${repoUrl}/commit/${record.commit}`}
+              className="font-mono text-[0.8125rem] font-medium text-accent hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {record.commit.slice(0, 7)}
+            </a>
+          </dd>
+        </div>
+
+        {published && (
+          <div className="min-w-0">
+            <dt className="text-xs uppercase tracking-wide text-muted">Published</dt>
+            <dd className="mt-0.5 font-medium">{published}</dd>
+          </div>
+        )}
+      </dl>
+    </section>
+  )
+}

--- a/upload-site/app/lib/github.ts
+++ b/upload-site/app/lib/github.ts
@@ -66,6 +66,33 @@ export async function createPullRequest(branch: string, title: string, body: str
   })
 }
 
+/**
+ * Reads a text file off the default branch, or null when it is not there.
+ *
+ * Goes through the API rather than raw.githubusercontent.com so the answer is
+ * never a CDN-cached copy - which matters for anything that grants access, such
+ * as the trusted publisher registry.
+ */
+export async function getFileContent(path: string): Promise<string | null> {
+  try {
+    const { data } = await octokit.rest.repos.getContent({
+      owner: REPO_OWNER,
+      repo: REPO_NAME,
+      path,
+      headers: { 'If-None-Match': '' },
+    })
+    if (Array.isArray(data) || data.type !== 'file' || typeof data.content !== 'string') {
+      return null
+    }
+    return Buffer.from(data.content, 'base64').toString('utf8')
+  } catch (error) {
+    if (typeof error === 'object' && error && 'status' in error && error.status === 404) {
+      return null
+    }
+    throw error
+  }
+}
+
 export async function deleteFile(path: string, message: string, sha: string, branch: string) {
   return octokit.rest.repos.deleteFile({
     owner: REPO_OWNER,

--- a/upload-site/app/lib/github.ts
+++ b/upload-site/app/lib/github.ts
@@ -43,18 +43,46 @@ export async function branchExists(branch: string): Promise<boolean> {
   }
 }
 
+/** Every branch whose name begins with `prefix`, newest-first order not promised. */
+export async function branchesWithPrefix(prefix: string): Promise<string[]> {
+  try {
+    const { data } = await octokit.rest.git.listMatchingRefs({
+      owner: REPO_OWNER,
+      repo: REPO_NAME,
+      ref: `heads/${prefix}`,
+    })
+    return data.map((ref) => ref.ref.replace(/^refs\/heads\//, ''))
+  } catch (error) {
+    const status =
+      typeof error === 'object' && error && 'status' in error ? error.status : null
+    if (status === 404) {
+      return []
+    }
+    throw error
+  }
+}
+
+/** The open pull request built on `branch`, or null when nothing is open for it. */
+export async function openPullRequestForBranch(branch: string) {
+  const { data } = await octokit.rest.pulls.list({
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    state: 'open',
+    head: `${REPO_OWNER}:${branch}`,
+    per_page: 1,
+  })
+  return data[0] ?? null
+}
+
 /**
  * Drop a branch, ignoring one that is already gone.
  *
  * Used to undo a publish that failed partway: without it a run that died
  * between creating the branch and opening the pull request would leave the
- * branch behind, and the retry - which derives the same name - would collide
- * with it rather than start clean.
+ * branch behind, unreachable by every gate that reviews a publish.
  *
- * Returns whether the branch is now gone. A caller that derives the branch
- * name deterministically needs to know when it is not: the wreckage will meet
- * every later request for that run, so the failure has to be said out loud
- * rather than swallowed here.
+ * Returns whether the branch is now gone, so a caller can say so rather than
+ * have the failure swallowed here.
  */
 export async function deleteBranch(branch: string): Promise<boolean> {
   try {

--- a/upload-site/app/lib/github.ts
+++ b/upload-site/app/lib/github.ts
@@ -24,6 +24,26 @@ export async function createBranch(newBranch: string, fromBranch: string) {
   })
 }
 
+/**
+ * Drop a branch, ignoring one that is already gone.
+ *
+ * Used to undo a publish that failed partway: without it a run that died
+ * between creating the branch and opening the pull request would leave the
+ * branch behind, and the retry - which derives the same name - would collide
+ * with it rather than start clean.
+ */
+export async function deleteBranch(branch: string): Promise<void> {
+  try {
+    await octokit.rest.git.deleteRef({
+      owner: REPO_OWNER,
+      repo: REPO_NAME,
+      ref: `heads/${branch}`,
+    })
+  } catch (error) {
+    console.warn(`Could not delete branch ${branch}:`, error)
+  }
+}
+
 export async function getFileSha(path: string) {
   try {
     const response = await octokit.rest.repos.getContent({

--- a/upload-site/app/lib/github.ts
+++ b/upload-site/app/lib/github.ts
@@ -24,6 +24,25 @@ export async function createBranch(newBranch: string, fromBranch: string) {
   })
 }
 
+/** Whether a branch is there, without caring what it points at. */
+export async function branchExists(branch: string): Promise<boolean> {
+  try {
+    await octokit.rest.git.getRef({
+      owner: REPO_OWNER,
+      repo: REPO_NAME,
+      ref: `heads/${branch}`,
+    })
+    return true
+  } catch (error) {
+    const status =
+      typeof error === 'object' && error && 'status' in error ? error.status : null
+    if (status === 404) {
+      return false
+    }
+    throw error
+  }
+}
+
 /**
  * Drop a branch, ignoring one that is already gone.
  *
@@ -31,16 +50,29 @@ export async function createBranch(newBranch: string, fromBranch: string) {
  * between creating the branch and opening the pull request would leave the
  * branch behind, and the retry - which derives the same name - would collide
  * with it rather than start clean.
+ *
+ * Returns whether the branch is now gone. A caller that derives the branch
+ * name deterministically needs to know when it is not: the wreckage will meet
+ * every later request for that run, so the failure has to be said out loud
+ * rather than swallowed here.
  */
-export async function deleteBranch(branch: string): Promise<void> {
+export async function deleteBranch(branch: string): Promise<boolean> {
   try {
     await octokit.rest.git.deleteRef({
       owner: REPO_OWNER,
       repo: REPO_NAME,
       ref: `heads/${branch}`,
     })
+    return true
   } catch (error) {
+    const status =
+      typeof error === 'object' && error && 'status' in error ? error.status : null
+    // Already gone is the outcome we wanted.
+    if (status === 404 || status === 422) {
+      return true
+    }
     console.warn(`Could not delete branch ${branch}:`, error)
+    return false
   }
 }
 

--- a/upload-site/app/lib/github.ts
+++ b/upload-site/app/lib/github.ts
@@ -104,22 +104,38 @@ export async function deleteBranch(branch: string): Promise<boolean> {
   }
 }
 
-export async function getFileSha(path: string) {
+/**
+ * The blob sha of a file, or null when there is no such file.
+ *
+ * A caller reads null as "not there yet" and goes on to create the file, so
+ * only a 404 may answer null: turning a rate limit or a 502 into the same
+ * answer has them write over a file they believe is absent, which GitHub then
+ * refuses for want of the sha they did not pass.
+ *
+ * `ref` is the branch, tag or commit to look on, and defaults to the
+ * repository's default branch.
+ */
+export async function getFileSha(path: string, ref?: string): Promise<string | null> {
   try {
     const response = await octokit.rest.repos.getContent({
       owner: REPO_OWNER,
       repo: REPO_NAME,
       path,
+      ref,
     })
-    
-    // Response is a single file
-    if (!Array.isArray(response.data)) {
-      return response.data.sha
+
+    // A directory rather than a file: nothing here to replace.
+    if (Array.isArray(response.data)) {
+      return null
     }
-    return null
+    return response.data.sha
   } catch (error) {
-    // File doesn't exist
-    return null
+    const status =
+      typeof error === 'object' && error && 'status' in error ? error.status : null
+    if (status === 404) {
+      return null
+    }
+    throw error
   }
 }
 

--- a/upload-site/app/lib/oidc.ts
+++ b/upload-site/app/lib/oidc.ts
@@ -1,0 +1,142 @@
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose'
+
+/**
+ * Verification of the OIDC ID tokens GitHub Actions mints for a workflow run.
+ *
+ * A workflow that asks for one gets a short-lived JWT, signed by GitHub, whose
+ * claims say which repository, which workflow file and which commit it was
+ * issued to. That is enough to let a workflow publish a package without anyone
+ * having to store a long-lived credential: the token IS the proof of identity,
+ * it cannot be replayed anywhere else (the audience is pinned to us) and it
+ * expires within minutes.
+ *
+ * Nothing here decides whether a verified run is *allowed* to publish - that is
+ * trustedPublishers.ts, working from the claims this returns.
+ */
+
+export const ISSUER = 'https://token.actions.githubusercontent.com'
+
+/**
+ * The `aud` we require. A token minted for some other service cannot be
+ * forwarded to us, and a token minted for us is useless anywhere else, so a
+ * workflow asking for this audience is stating who it is talking to.
+ */
+export const PUBLISH_AUDIENCE = 'https://packages.mudlet.org'
+
+/**
+ * jose caches the fetched keys and re-fetches on an unknown `kid`, with a
+ * cooldown so a bad token cannot turn into a fetch loop against GitHub.
+ */
+const jwks = createRemoteJWKSet(new URL(`${ISSUER}/.well-known/jwks`), {
+  cacheMaxAge: 10 * 60 * 1000,
+  cooldownDuration: 30 * 1000,
+  timeoutDuration: 5000,
+})
+
+/**
+ * The subset of the GitHub Actions claim set this service reads. GitHub sends
+ * every one of these as a string, ids included.
+ */
+export interface ActionsClaims extends JWTPayload {
+  /** "owner/repo" at the time of the run - display only, see repository_id. */
+  repository: string
+  /** Numeric, immutable. This, not the name, is what identifies a repository. */
+  repository_id: string
+  repository_owner: string
+  /** Numeric, immutable. Survives an account rename. */
+  repository_owner_id: string
+  /**
+   * "owner/repo/.github/workflows/publish.yml@refs/heads/main" - the workflow
+   * file that actually contains the running job. Unlike workflow_ref this is
+   * not forgeable by calling a reusable workflow, so it is what we pin to.
+   */
+  job_workflow_ref: string
+  /** The entry-point workflow, which may differ from job_workflow_ref. */
+  workflow_ref: string
+  /** "refs/heads/main", "refs/tags/v1.2.3", ... */
+  ref: string
+  sha: string
+  event_name: string
+  /** Present only when the job declared an environment. */
+  environment?: string
+  /** "github-hosted" or "self-hosted". */
+  runner_environment: string
+  run_id: string
+  run_attempt: string
+}
+
+const REQUIRED_CLAIMS = [
+  'repository',
+  'repository_id',
+  'repository_owner',
+  'repository_owner_id',
+  'job_workflow_ref',
+  'ref',
+  'sha',
+  'event_name',
+  'runner_environment',
+  'run_id',
+] as const
+
+export class TokenError extends Error {}
+
+/**
+ * Verifies signature, issuer, audience and expiry, and returns the claims.
+ * Throws TokenError with a message safe to hand back to the caller.
+ */
+export async function verifyActionsToken(token: string): Promise<ActionsClaims> {
+  let payload: JWTPayload
+  try {
+    const result = await jwtVerify(token, jwks, {
+      issuer: ISSUER,
+      audience: PUBLISH_AUDIENCE,
+      // The tokens are minted for this request; allow only a little clock drift.
+      clockTolerance: 30,
+      maxTokenAge: '15 minutes',
+    })
+    payload = result.payload
+  } catch (error) {
+    throw new TokenError(
+      `OIDC token rejected: ${error instanceof Error ? error.message : 'unknown error'}`,
+    )
+  }
+
+  for (const claim of REQUIRED_CLAIMS) {
+    if (typeof payload[claim] !== 'string' || !payload[claim]) {
+      throw new TokenError(`OIDC token is missing the '${claim}' claim`)
+    }
+  }
+
+  return payload as ActionsClaims
+}
+
+/** Reads the bearer token out of an Authorization header. */
+export function bearerToken(request: Request): string | null {
+  const header = request.headers.get('authorization')
+  if (!header) return null
+  const match = header.match(/^Bearer\s+(\S+)$/i)
+  return match ? match[1] : null
+}
+
+/**
+ * Best-effort replay guard. Serverless instances do not share memory, so this
+ * cannot be the only thing standing between us and a replayed token - it is not
+ * load-bearing, and the real protections are the short expiry and the pinned
+ * audience. Replaying a token within its lifetime opens a duplicate pull
+ * request, which a maintainer closes; it cannot land anything on its own.
+ */
+const seenTokens = new Map<string, number>()
+
+export function rememberToken(claims: ActionsClaims): boolean {
+  const id = typeof claims.jti === 'string' ? claims.jti : null
+  if (!id) return true
+
+  const now = Date.now()
+  for (const [key, expiry] of seenTokens) {
+    if (expiry <= now) seenTokens.delete(key)
+  }
+
+  if (seenTokens.has(id)) return false
+  seenTokens.set(id, (claims.exp ?? Math.floor(now / 1000) + 900) * 1000)
+  return true
+}

--- a/upload-site/app/lib/oidc.ts
+++ b/upload-site/app/lib/oidc.ts
@@ -76,6 +76,7 @@ const REQUIRED_CLAIMS = [
   'event_name',
   'runner_environment',
   'run_id',
+  'run_attempt',
 ] as const
 
 export class TokenError extends Error {}

--- a/upload-site/app/lib/provenance.ts
+++ b/upload-site/app/lib/provenance.ts
@@ -1,0 +1,108 @@
+import { createHash } from 'crypto'
+import { existsSync, promises as fs } from 'fs'
+import path from 'path'
+import { RAW_BASE } from './urls'
+
+/**
+ * What is actually known about where a published archive came from.
+ *
+ * This is deliberately not the same thing as trusted-publishers.json. That file
+ * says which workflow is *allowed* to publish a package - an intention, decided
+ * before any archive exists. It cannot say how the file now sitting in
+ * packages/ got there, and a package with an entry can still be replaced by a
+ * website upload or an ordinary fork-and-pull-request. A badge driven by the
+ * registry would keep vouching for the origin of a file nobody checked.
+ *
+ * So provenance is recorded per artifact, at the moment the publish endpoint
+ * accepts one, and pinned to the bytes it accepted. Anything that later
+ * replaces those bytes - by any route, including a maintainer committing
+ * directly - changes the digest, the record stops matching, and the badge
+ * disappears on its own. It fails closed and needs nobody to remember to
+ * revoke it.
+ *
+ * One file per package, rather than one registry for all of them: two packages
+ * publishing at once would otherwise be editing the same file on two branches
+ * cut from the same commit, and the second to merge would land in conflict.
+ * Sharded, concurrent publishes never touch the same path.
+ */
+
+export const PROVENANCE_DIR = 'provenance'
+
+/** provenance/<the file in packages/>.json - e.g. provenance/arkadia.mpackage.json */
+export function provenancePathFor(filename: string): string {
+  return `${PROVENANCE_DIR}/${filename}.json`
+}
+
+export interface ProvenanceRecord {
+  /** The file in packages/ this describes. */
+  filename: string
+  /** Package name from config.lua, for display. */
+  mpackage: string
+  /** Hex sha-256 of the exact archive that was published. The whole point. */
+  sha256: string
+  version: string
+  /** "owner/repo" the OIDC token was issued to. */
+  repository: string
+  /** Numeric repository id - what the token was actually matched on. */
+  repositoryId: string
+  /** Repo-relative workflow file that published it. */
+  workflow: string
+  /** Ref the publishing run was on, e.g. "refs/heads/main". */
+  ref: string
+  /** Commit the run was building. */
+  commit: string
+  runId: string
+  publishedAt: string
+}
+
+export function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex')
+}
+
+export function serialiseRecord(record: ProvenanceRecord): string {
+  return `${JSON.stringify(record, null, 2)}\n`
+}
+
+const localProvenanceDir = path.join(process.cwd(), '..', PROVENANCE_DIR)
+
+/**
+ * Read one package's record: the checkout during the build, the published copy
+ * at request time. A package with no record is the normal case, not an error.
+ */
+async function loadRecord(filename: string): Promise<ProvenanceRecord | null> {
+  try {
+    let raw: string | null
+    if (existsSync(localProvenanceDir)) {
+      const file = path.join(localProvenanceDir, `${filename}.json`)
+      if (!existsSync(file)) return null
+      raw = await fs.readFile(file, 'utf8')
+    } else {
+      const url = `${RAW_BASE}/${PROVENANCE_DIR}/${encodeURIComponent(`${filename}.json`)}`
+      const response = await fetch(url)
+      raw = response.ok ? await response.text() : null
+    }
+    if (raw === null) return null
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed.sha256 === 'string' ? (parsed as ProvenanceRecord) : null
+  } catch {
+    // A package page is worth rendering without its provenance panel.
+    return null
+  }
+}
+
+/**
+ * The provenance of the archive as it stands right now, or null.
+ *
+ * `archive` must be the bytes currently published under `filename`. A record
+ * that does not match them is not stale metadata to be shown with a caveat -
+ * it describes a different file, so it says nothing about this one.
+ */
+export async function verifiedProvenance(
+  filename: string | null,
+  archive: Buffer,
+): Promise<ProvenanceRecord | null> {
+  if (!filename) return null
+  const record = await loadRecord(filename)
+  if (!record?.sha256) return null
+  return record.sha256.toLowerCase() === sha256(archive) ? record : null
+}

--- a/upload-site/app/lib/provenance.ts
+++ b/upload-site/app/lib/provenance.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto'
 import { existsSync, promises as fs } from 'fs'
 import path from 'path'
+import { readsFromCheckout } from './packages'
 import { RAW_BASE } from './urls'
 
 /**
@@ -66,13 +67,46 @@ export function serialiseRecord(record: ProvenanceRecord): string {
 const localProvenanceDir = path.join(process.cwd(), '..', PROVENANCE_DIR)
 
 /**
+ * Every field the record is written with, and every field a reader may reach
+ * for without checking first. A record short of any of them was not written by
+ * the publish endpoint, and the digest matching says nothing about the rest of
+ * it - the panel dereferences `commit` and `workflow`, so a record carrying
+ * only a sha256 would throw during the render of a page that has no business
+ * failing over its provenance panel.
+ */
+const RECORD_FIELDS = [
+  'filename',
+  'mpackage',
+  'sha256',
+  'version',
+  'repository',
+  'repositoryId',
+  'workflow',
+  'ref',
+  'commit',
+  'runId',
+  'publishedAt',
+] as const
+
+function isRecord(value: unknown): value is ProvenanceRecord {
+  if (!value || typeof value !== 'object') return false
+  const fields = value as Record<string, unknown>
+  return RECORD_FIELDS.every((field) => typeof fields[field] === 'string' && fields[field] !== '')
+}
+
+/**
  * Read one package's record: the checkout during the build, the published copy
  * at request time. A package with no record is the normal case, not an error.
+ *
+ * Which of the two is decided by whether the checkout is there at all, not by
+ * whether it holds a provenance directory. Before the first trusted publish
+ * there is no such directory, and reading its absence as "ask the network" had
+ * the build fetch a 404 for every package it prerendered.
  */
 async function loadRecord(filename: string): Promise<ProvenanceRecord | null> {
   try {
     let raw: string | null
-    if (existsSync(localProvenanceDir)) {
+    if (readsFromCheckout) {
       const file = path.join(localProvenanceDir, `${filename}.json`)
       if (!existsSync(file)) return null
       raw = await fs.readFile(file, 'utf8')
@@ -82,8 +116,8 @@ async function loadRecord(filename: string): Promise<ProvenanceRecord | null> {
       raw = response.ok ? await response.text() : null
     }
     if (raw === null) return null
-    const parsed = JSON.parse(raw)
-    return parsed && typeof parsed.sha256 === 'string' ? (parsed as ProvenanceRecord) : null
+    const parsed: unknown = JSON.parse(raw)
+    return isRecord(parsed) ? parsed : null
   } catch {
     // A package page is worth rendering without its provenance panel.
     return null

--- a/upload-site/app/lib/trustedPublishers.ts
+++ b/upload-site/app/lib/trustedPublishers.ts
@@ -121,7 +121,13 @@ export function authorise(
     throw new PublisherError('the token\'s job_workflow_ref claim is malformed')
   }
 
-  const match = forRepo.find((p) => sameName(path, `${p.repository}/${p.workflow}`))
+  // Built from the token's own repository name, not the registry's copy of it.
+  // Which repository this is has already been settled by the ids above, and the
+  // name in the registry is only a label for people reading the file - it goes
+  // stale the moment the repository is renamed or transferred, and comparing
+  // against it would then reject every publish from the very workflow the entry
+  // exists to authorise. What is actually being pinned here is the workflow path.
+  const match = forRepo.find((p) => sameName(path, `${claims.repository}/${p.workflow}`))
   if (!match) {
     throw new PublisherError(
       `workflow ${path} is not the workflow registered to publish for this repository`,

--- a/upload-site/app/lib/trustedPublishers.ts
+++ b/upload-site/app/lib/trustedPublishers.ts
@@ -80,11 +80,21 @@ export async function loadRegistry(): Promise<TrustedPublisher[]> {
 /**
  * job_workflow_ref is "owner/repo/.github/workflows/file.yml@refs/heads/main".
  * The ref is checked separately, so only the path half is compared here.
+ *
+ * Split at the "@" that introduces the ref, not at the last one in the string:
+ * a ref may carry an "@" of its own - "refs/tags/arkadia@1.2.3" is what
+ * changesets and semantic-release produce, and git accepts it - and splitting
+ * on the last would hand back a path with half the tag glued to it, refusing
+ * the publish with a message about a workflow file nobody wrote.
  */
 function workflowPathOf(jobWorkflowRef: string): string | null {
-  const at = jobWorkflowRef.lastIndexOf('@')
-  if (at === -1) return null
-  return jobWorkflowRef.slice(0, at)
+  const at = jobWorkflowRef.lastIndexOf('@refs/')
+  // GitHub has always put a full ref here, but a claim shaped some other way
+  // is better split on its last "@" than refused outright - the path still has
+  // to match an entry character for character afterwards.
+  const fallback = at === -1 ? jobWorkflowRef.lastIndexOf('@') : at
+  if (fallback === -1) return null
+  return jobWorkflowRef.slice(0, fallback)
 }
 
 /**
@@ -107,7 +117,13 @@ function sameName(a: string, b: string): boolean {
 }
 
 /**
- * Finds the registry entry that authorises this run, or explains why none did.
+ * Every registry entry this run may act for, or an explanation of why none did.
+ *
+ * A list rather than one entry: a repository is free to register several of its
+ * packages against the same workflow file, and picking the first of them here
+ * would leave every package but that one unpublishable. Which of these the run
+ * is actually publishing is not known until config.lua has been read, so
+ * publisherFor below finishes the job.
  *
  * The explanation deliberately does not distinguish "no entry for this
  * repository" from "entry exists but the workflow differs" in a way that would
@@ -118,7 +134,7 @@ function sameName(a: string, b: string): boolean {
 export function authorise(
   claims: ActionsClaims,
   publishers: TrustedPublisher[],
-): TrustedPublisher {
+): TrustedPublisher[] {
   const forRepo = publishers.filter(
     (p) =>
       p.repositoryId === claims.repository_id &&
@@ -149,10 +165,37 @@ export function authorise(
   // different files that can sit in one repository at once. Folding case would
   // let the one nobody registered publish under the registered one's name.
   const actualWorkflow = repoRelativeWorkflow(path, claims.repository)
-  const match = forRepo.find((p) => p.workflow.trim() === actualWorkflow)
-  if (!match) {
+  const forWorkflow = forRepo.filter((p) => p.workflow.trim() === actualWorkflow)
+  if (forWorkflow.length === 0) {
     throw new PublisherError(
       `workflow ${path} is not the workflow registered to publish for this repository`,
+    )
+  }
+
+  return forWorkflow
+}
+
+/**
+ * Which of the authorised entries this archive is, and whether the run meets
+ * the conditions that entry puts on it.
+ *
+ * The package named in config.lua is what chooses the entry - without that an
+ * authorised workflow could publish over anything else in the repository. The
+ * ref, environment and runner conditions are checked here rather than in
+ * authorise because they belong to the entry rather than to the repository: two
+ * packages published by one workflow may each be pinned differently.
+ */
+export function publisherFor(
+  claims: ActionsClaims,
+  authorised: TrustedPublisher[],
+  mpackage: string | null,
+): TrustedPublisher {
+  const match = mpackage ? authorised.find((p) => sameName(p.mpackage, mpackage)) : undefined
+  if (!match) {
+    const registered = authorised.map((p) => `"${p.mpackage}"`).join(', ')
+    throw new PublisherError(
+      `config.lua declares mpackage "${mpackage ?? ''}", but this workflow is ` +
+        `registered to publish ${registered}`,
     )
   }
 
@@ -176,22 +219,6 @@ export function authorise(
   }
 
   return match
-}
-
-/**
- * The package being uploaded has to be the package the entry is for. Without
- * this an authorised workflow could publish over anything in the repository.
- */
-export function assertPackageMatches(
-  publisher: TrustedPublisher,
-  mpackage: string | null,
-): void {
-  if (!mpackage || !sameName(mpackage, publisher.mpackage)) {
-    throw new PublisherError(
-      `config.lua declares mpackage "${mpackage ?? ''}", but this publisher is ` +
-        `registered for "${publisher.mpackage}"`,
-    )
-  }
 }
 
 /** Guards against an entry naming a path instead of a file in packages/. */

--- a/upload-site/app/lib/trustedPublishers.ts
+++ b/upload-site/app/lib/trustedPublishers.ts
@@ -30,9 +30,10 @@ export interface TrustedPublisher {
   repositoryOwnerId: string
   /**
    * Repo-relative path of the workflow allowed to publish, e.g.
-   * ".github/workflows/publish.yml". Matched against the token's
-   * job_workflow_ref, so it pins the actual file the job came from - without
-   * it, *any* workflow anyone can land in that repository could publish.
+   * ".github/workflows/publish.yml". Matched exactly, case included, against
+   * the token's job_workflow_ref, so it pins the actual file the job came from
+   * - without it, *any* workflow anyone can land in that repository could
+   * publish.
    */
   workflow: string
   /** Optional: require the run to be on this exact ref, e.g. "refs/heads/main". */
@@ -86,6 +87,21 @@ function workflowPathOf(jobWorkflowRef: string): string | null {
   return jobWorkflowRef.slice(0, at)
 }
 
+/**
+ * Strips the leading "owner/repo/" so what is left is what the registry stores.
+ *
+ * Only the repository half folds case - GitHub treats owner and repository
+ * names case-insensitively - and only that half. A job run through a reusable
+ * workflow in another repository names that repository here, and keeping its
+ * path whole is what stops it from ever equalling a repo-relative entry.
+ */
+function repoRelativeWorkflow(path: string, repository: string): string {
+  const prefix = `${repository}/`
+  return path.slice(0, prefix.length).toLowerCase() === prefix.toLowerCase()
+    ? path.slice(prefix.length)
+    : path
+}
+
 function sameName(a: string, b: string): boolean {
   return a.trim().toLowerCase() === b.trim().toLowerCase()
 }
@@ -121,13 +137,19 @@ export function authorise(
     throw new PublisherError('the token\'s job_workflow_ref claim is malformed')
   }
 
-  // Built from the token's own repository name, not the registry's copy of it.
-  // Which repository this is has already been settled by the ids above, and the
-  // name in the registry is only a label for people reading the file - it goes
-  // stale the moment the repository is renamed or transferred, and comparing
-  // against it would then reject every publish from the very workflow the entry
-  // exists to authorise. What is actually being pinned here is the workflow path.
-  const match = forRepo.find((p) => sameName(path, `${claims.repository}/${p.workflow}`))
+  // Compared against the token's own repository name, not the registry's copy
+  // of it. Which repository this is has already been settled by the ids above,
+  // and the name in the registry is only a label for people reading the file -
+  // it goes stale the moment the repository is renamed or transferred, and
+  // comparing against it would then reject every publish from the very workflow
+  // the entry exists to authorise. What is pinned here is the workflow path.
+  //
+  // Character for character, case included: git paths are case-sensitive, so
+  // .github/workflows/Publish.yml and .github/workflows/publish.yml are two
+  // different files that can sit in one repository at once. Folding case would
+  // let the one nobody registered publish under the registered one's name.
+  const actualWorkflow = repoRelativeWorkflow(path, claims.repository)
+  const match = forRepo.find((p) => p.workflow.trim() === actualWorkflow)
   if (!match) {
     throw new PublisherError(
       `workflow ${path} is not the workflow registered to publish for this repository`,

--- a/upload-site/app/lib/trustedPublishers.ts
+++ b/upload-site/app/lib/trustedPublishers.ts
@@ -1,0 +1,176 @@
+import { getFileContent } from './github'
+import type { ActionsClaims } from './oidc'
+
+/**
+ * The trusted publisher registry: which GitHub Actions workflow, if any, is
+ * allowed to publish a given package without a human driving the upload.
+ *
+ * The registry lives in trusted-publishers.json at the root of this repository,
+ * so adding a publisher is an ordinary pull request and a maintainer reviewing
+ * it *is* the authorization step. Nothing else grants publish rights, and a
+ * package with no entry here can only be uploaded the usual way.
+ */
+
+export const REGISTRY_PATH = 'trusted-publishers.json'
+
+export interface TrustedPublisher {
+  /** The `mpackage` name in the package's config.lua. Compared case-insensitively. */
+  mpackage: string
+  /** File the package lands on as packages/<filename>. */
+  filename: string
+  /** "owner/repo", for humans reading the file and for error messages. */
+  repository: string
+  /**
+   * GitHub's numeric ids. These are what a token is actually matched against:
+   * a repository or account can be renamed, transferred, deleted and recreated
+   * by someone else, and every one of those keeps the old "owner/repo" string
+   * working while pointing somewhere new. The ids do not move.
+   */
+  repositoryId: string
+  repositoryOwnerId: string
+  /**
+   * Repo-relative path of the workflow allowed to publish, e.g.
+   * ".github/workflows/publish.yml". Matched against the token's
+   * job_workflow_ref, so it pins the actual file the job came from - without
+   * it, *any* workflow anyone can land in that repository could publish.
+   */
+  workflow: string
+  /** Optional: require the run to be on this exact ref, e.g. "refs/heads/main". */
+  ref?: string | null
+  /**
+   * Optional: require the job to run in this GitHub environment. An environment
+   * with required reviewers turns publishing into something a human approves.
+   */
+  environment?: string | null
+  /** Self-hosted runners are outside GitHub's control; opt in deliberately. */
+  allowSelfHostedRunner?: boolean
+}
+
+interface Registry {
+  publishers: TrustedPublisher[]
+}
+
+export class PublisherError extends Error {}
+
+function parseRegistry(raw: string): TrustedPublisher[] {
+  let parsed: Registry
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new PublisherError('the trusted publisher registry is not valid JSON')
+  }
+  if (!parsed || !Array.isArray(parsed.publishers)) {
+    throw new PublisherError('the trusted publisher registry has no "publishers" array')
+  }
+  return parsed.publishers
+}
+
+/**
+ * Read through the GitHub API rather than raw.githubusercontent.com: raw is
+ * behind a CDN with minutes of caching, and minutes is exactly the window in
+ * which a revoked publisher would still be able to publish.
+ */
+export async function loadRegistry(): Promise<TrustedPublisher[]> {
+  const raw = await getFileContent(REGISTRY_PATH)
+  if (raw === null) return []
+  return parseRegistry(raw)
+}
+
+/**
+ * job_workflow_ref is "owner/repo/.github/workflows/file.yml@refs/heads/main".
+ * The ref is checked separately, so only the path half is compared here.
+ */
+function workflowPathOf(jobWorkflowRef: string): string | null {
+  const at = jobWorkflowRef.lastIndexOf('@')
+  if (at === -1) return null
+  return jobWorkflowRef.slice(0, at)
+}
+
+function sameName(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase()
+}
+
+/**
+ * Finds the registry entry that authorises this run, or explains why none did.
+ *
+ * The explanation deliberately does not distinguish "no entry for this
+ * repository" from "entry exists but the workflow differs" in a way that would
+ * let someone enumerate the registry - the registry is a public file in this
+ * repository, so there is nothing to hide, but the message stays about the
+ * caller's own token rather than about what else is registered.
+ */
+export function authorise(
+  claims: ActionsClaims,
+  publishers: TrustedPublisher[],
+): TrustedPublisher {
+  const forRepo = publishers.filter(
+    (p) =>
+      p.repositoryId === claims.repository_id &&
+      p.repositoryOwnerId === claims.repository_owner_id,
+  )
+
+  if (forRepo.length === 0) {
+    throw new PublisherError(
+      `no trusted publisher is registered for repository ${claims.repository} ` +
+        `(id ${claims.repository_id}). Open a pull request adding one to ${REGISTRY_PATH}.`,
+    )
+  }
+
+  const path = workflowPathOf(claims.job_workflow_ref)
+  if (!path) {
+    throw new PublisherError('the token\'s job_workflow_ref claim is malformed')
+  }
+
+  const match = forRepo.find((p) => sameName(path, `${p.repository}/${p.workflow}`))
+  if (!match) {
+    throw new PublisherError(
+      `workflow ${path} is not the workflow registered to publish for this repository`,
+    )
+  }
+
+  if (match.ref && match.ref !== claims.ref) {
+    throw new PublisherError(
+      `this publisher may only publish from ${match.ref}, the run was on ${claims.ref}`,
+    )
+  }
+
+  if (match.environment && match.environment !== claims.environment) {
+    throw new PublisherError(
+      `this publisher must run in the '${match.environment}' environment` +
+        (claims.environment ? `, the run used '${claims.environment}'` : ', the run declared none'),
+    )
+  }
+
+  if (claims.runner_environment !== 'github-hosted' && !match.allowSelfHostedRunner) {
+    throw new PublisherError(
+      'this publisher is not permitted to publish from a self-hosted runner',
+    )
+  }
+
+  return match
+}
+
+/**
+ * The package being uploaded has to be the package the entry is for. Without
+ * this an authorised workflow could publish over anything in the repository.
+ */
+export function assertPackageMatches(
+  publisher: TrustedPublisher,
+  mpackage: string | null,
+): void {
+  if (!mpackage || !sameName(mpackage, publisher.mpackage)) {
+    throw new PublisherError(
+      `config.lua declares mpackage "${mpackage ?? ''}", but this publisher is ` +
+        `registered for "${publisher.mpackage}"`,
+    )
+  }
+}
+
+/** Guards against an entry naming a path instead of a file in packages/. */
+export function assertFilenameSane(filename: string): void {
+  if (!/^[^/\\]+\.(mpackage|zip)$/i.test(filename)) {
+    throw new PublisherError(
+      `registered filename "${filename}" is not a plain .mpackage or .zip file name`,
+    )
+  }
+}

--- a/upload-site/app/packages/[name]/page.tsx
+++ b/upload-site/app/packages/[name]/page.tsx
@@ -14,6 +14,8 @@ import { InstallCommands } from '@/app/components/InstallCommands'
 import { DragToInstall } from '@/app/components/DragToInstall'
 import { PackageDescription } from '@/app/components/PackageDescription'
 import { AuthorCredit } from '@/app/components/AuthorCredit'
+import { TrustedPublisherPanel } from '@/app/components/TrustedPublisher'
+import { verifiedProvenance, type ProvenanceRecord } from '@/app/lib/provenance'
 import { formatDate, packageDownloadUrl, packageIconUrl, packageSlug } from '@/app/lib/urls'
 
 type PageProps = { params: Promise<{ name: string }> }
@@ -63,6 +65,22 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 /**
+ * Provenance is checked against the archive itself, so this hashes the file the
+ * page is offering rather than trusting the record. getArchiveBuffer reads the
+ * checkout during the build and caches at request time, and ContentsSection
+ * below wants the same bytes, so this costs a hash rather than a download.
+ */
+async function provenanceFor(filename: string | null): Promise<ProvenanceRecord | null> {
+  if (!filename) return null
+  try {
+    return await verifiedProvenance(filename, await getArchiveBuffer(filename))
+  } catch {
+    // An archive we cannot read is one we cannot vouch for.
+    return null
+  }
+}
+
+/**
  * Unpacking runs during the page render rather than behind a Suspense
  * boundary: streamed boundaries in this app never hydrate on a hard load, which
  * left the explorer dead until a client-side navigation.
@@ -87,6 +105,7 @@ export default async function PackagePage({ params }: PageProps) {
   if (!pkg || !pkg.filename) notFound()
 
   const iconUrl = packageIconUrl(pkg.icon)
+  const provenance = await provenanceFor(pkg.filename)
   const facts = [
     pkg.version && { label: 'Version', value: pkg.version },
     pkg.author && { label: 'Author', value: <AuthorCredit author={pkg.author} /> },
@@ -145,6 +164,8 @@ export default async function PackagePage({ params }: PageProps) {
           downloadUrl={packageDownloadUrl(pkg.filename)}
         />
       </div>
+
+      {provenance && <TrustedPublisherPanel record={provenance} />}
 
       {pkg.description && (
         <section className="mt-8">

--- a/upload-site/package-lock.json
+++ b/upload-site/package-lock.json
@@ -14,6 +14,7 @@
         "fast-xml-parser": "^5.2.5",
         "framer-motion": "^12.0.3",
         "highlight.js": "^11.12.0",
+        "jose": "^5.10.0",
         "next": "^16.3.0",
         "next-auth": "^4.24.15",
         "next-sitemap": "^4.2.3",
@@ -4668,6 +4669,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/upload-site/package.json
+++ b/upload-site/package.json
@@ -19,6 +19,7 @@
     "fast-xml-parser": "^5.2.5",
     "framer-motion": "^12.0.3",
     "highlight.js": "^11.12.0",
+    "jose": "^5.10.0",
     "next": "^16.3.0",
     "next-auth": "^4.24.15",
     "next-sitemap": "^4.2.3",


### PR DESCRIPTION
A package author who builds in GitHub Actions currently has two ways to get a new version here, and both need a human: the upload form, or a fork and a pull request. Automating either means storing a personal access token in their repository, which is a long-lived credential with far more reach than publishing one package.

GitHub already mints a short-lived OIDC token describing a workflow run - which repository, which workflow file, which commit. That is enough to identify a publisher without anyone holding a secret, so this adds an endpoint that accepts one:

- trusted-publishers.json says which workflow may publish which package. Editing it is an ordinary pull request, so a maintainer's review is the authorization step, and nothing else grants publish rights.
- /api/publish verifies the token against GitHub's keys and the registry, then opens the same branch-and-pull-request the upload form does. Every existing gate still applies: this changes who may ask, never what lands.

Matching is on GitHub's numeric ids rather than "owner/repo", because a repository can be renamed, transferred, or deleted and recreated by somebody else and all of those leave the old name resolving somewhere new. It pins job_workflow_ref too, not just the repository - otherwise any workflow anyone lands in that repository could publish, and a pull request is often enough to add one.

Package pages gain a "built and published from source" panel, driven by provenance/<file>.json rather than by the registry. The registry records an intention decided before any archive exists; it cannot say how the file now in packages/ got there, and a registered package can still be replaced by an upload or a hand-written pull request. So the digest of the accepted bytes is recorded alongside the run, and the panel appears only if it still describes the file being served - it fails closed, with nothing to remember to revoke. One record per package, because a shared file would put two concurrent publishes in conflict.

Those records are what the panel trusts, so they stay out of reach: auto-merge accepts one only from a trusted-publish/* branch in this repository opened by the machine account, and then only the record belonging to the package in that same pull request.

validate-mpackage.yml counts package files rather than all changed files, so a provenance record may accompany one. It now reads statuses from the API, which also fixes a rename through the upload form - that deletes the old archive in the same pull request, and the deletion was counting towards the one-package limit.