### PR TITLE
Only flag questionable content a PR actually introduces

### DIFF
--- a/.github/workflows/validate-mpackage.yml
+++ b/.github/workflows/validate-mpackage.yml
@@ -129,45 +129,47 @@ jobs:
       run: |
         PATTERN='os\.exec|lfs\.rmdir|sysDataSendRequest'
 
-        # every line matching PATTERN, whitespace-normalised and sorted, so that two
-        # versions of the same package can be compared with comm
-        collect_matches() {
-          [ -d "$1" ] || return 0
-          grep -a -h -R -E "$PATTERN" "$1" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | LC_ALL=C sort
-        }
-
-        collect_matches unzipped_package > new_matches.txt
-
-        # Compare against the version of this package that is already on the base
-        # branch: whatever it matched there was looked at when it was merged, so only
-        # what this pull request introduces needs another manual look. Checking the
-        # whole package instead would freeze every package that legitimately uses one
-        # of these - handling sysDataSendRequest is how a mapper tracks movement (#755).
-        : > base_matches.txt
+        # Unpack the version of this package that is already on the base branch, so the
+        # two can be compared file by file. Whatever it matched there was looked at when
+        # it was merged; only what this pull request changes needs another manual look.
+        # Checking the whole package instead would freeze every package that legitimately
+        # uses one of these - handling sysDataSendRequest is how a mapper tracks
+        # movement, so those packages could never be updated again (#755).
         if git fetch --no-tags --depth=1 origin "$BASE_SHA" >/dev/null 2>&1 \
            && git cat-file -e "$BASE_SHA:$FILE" 2>/dev/null \
            && git show "$BASE_SHA:$FILE" > base_package.zip \
            && unzip -q -o base_package.zip -d unzipped_base_package; then
-          collect_matches unzipped_base_package > base_matches.txt
           echo "Comparing against ${FILE} as of ${BASE_SHA}."
         else
           # a new package, or the previous version could not be read: check it whole
           echo "No previous version of ${FILE} to compare against, checking the whole package."
         fi
 
-        INTRODUCED=$(LC_ALL=C comm -13 base_matches.txt new_matches.txt)
-        if [ -n "$INTRODUCED" ]; then
-          echo "Introduced by this pull request:"
-          echo "$INTRODUCED"
+        : > findings.txt
+        while IFS= read -r new_file; do
+          base_file="unzipped_base_package/${new_file#unzipped_package/}"
+          if [ -f "$base_file" ]; then
+            # Only report a match that this pull request touched: with 20 lines of context
+            # a diff hunk covers the handler or function a match sits in, so a match shows
+            # up in one when it is added, when it moves, and when the code around it is
+            # rewritten. Removed lines are dropped - taking a match out needs no review.
+            hits=$(diff -a -U20 "$base_file" "$new_file" | grep -v '^-' | grep -a -E "$PATTERN") || true
+          else
+            hits=$(grep -a -E "$PATTERN" "$new_file") || true
+          fi
+          if [ -n "$hits" ]; then
+            printf '%s:\n%s\n' "${new_file#unzipped_package/}" "$hits" >> findings.txt
+          fi
+        done < <(find unzipped_package -type f)
+
+        if [ -s findings.txt ]; then
+          echo "Added or changed by this pull request:"
+          cat findings.txt
           echo "::error:: questionable functions or events used, please validate manually"
           exit 1
         fi
 
-        if [ -s new_matches.txt ]; then
-          echo "Pass: security checks - every match was in the previous version of this package already"
-        else
-          echo "Pass: security checks"
-        fi
+        echo "Pass: security checks"
 
     - name: Extract package name and author, check for duplicates
       if: steps.skip-if-deleted.outputs.skip != 'true'

--- a/.github/workflows/validate-mpackage.yml
+++ b/.github/workflows/validate-mpackage.yml
@@ -153,7 +153,52 @@ jobs:
             # a diff hunk covers the handler or function a match sits in, so a match shows
             # up in one when it is added, when it moves, and when the code around it is
             # rewritten. Removed lines are dropped - taking a match out needs no review.
-            hits=$(diff -a -U20 "$base_file" "$new_file" | grep -v '^-' | grep -a -E "$PATTERN") || true
+        PATTERN_STRICT='os\.exec|lfs\.rmdir'
+        PATTERN_CONTEXTUAL='sysDataSendRequest'
+
+        # Check for unconditionally dangerous patterns anywhere in the package.
+        if grep -q -R -a -E "$PATTERN_STRICT" unzipped_package/; then
+          echo "::error:: unconditionally dangerous functions found (os.exec, lfs.rmdir), please validate manually"
+          exit 1
+        fi
+
+        # Unpack the version of this package that is already on the base branch, so the
+        # two can be compared file by file. Whatever it matched there was looked at when
+        # it was merged; only what this pull request changes needs another manual look.
+        # Checking the whole package instead would freeze every package that legitimately
+        # uses one of these - handling sysDataSendRequest is how a mapper tracks
+        # movement, so those packages could never be updated again (#755).
+        if git fetch --no-tags --depth=1 origin "$BASE_SHA" >/dev/null 2>&1 \
+           && git cat-file -e "$BASE_SHA:$FILE" 2>/dev/null \
+           && git show "$BASE_SHA:$FILE" > base_package.zip \
+           && unzip -q -o base_package.zip -d unzipped_base_package; then
+          echo "Comparing against ${FILE} as of ${BASE_SHA}."
+        else
+          # a new package, or the previous version could not be read: check it whole
+          echo "No previous version of ${FILE} to compare against, checking the whole package."
+        fi
+
+        : > findings.txt
+        while IFS= read -r new_file; do
+          base_file="unzipped_base_package/${new_file#unzipped_package/}"
+          if [ -f "$base_file" ]; then
+            hits=$(diff -a -U20 "$base_file" "$new_file" | grep -v '^-' | grep -a -E "$PATTERN_CONTEXTUAL") || true
+          else
+            hits=$(grep -a -E "$PATTERN_CONTEXTUAL" "$new_file") || true
+          fi
+          if [ -n "$hits" ]; then
+            printf '%s:\n%s\n' "${new_file#unzipped_package/}" "$hits" >> findings.txt
+          fi
+        done < <(find unzipped_package -type f)
+
+        if [ -s findings.txt ]; then
+          echo "Added or changed by this pull request:"
+          cat findings.txt
+          echo "::error:: questionable functions or events used, please validate manually"
+          exit 1
+        fi
+
+        echo "Pass: security checks"
           else
             hits=$(grep -a -E "$PATTERN" "$new_file") || true
           fi

--- a/.github/workflows/validate-mpackage.yml
+++ b/.github/workflows/validate-mpackage.yml
@@ -127,14 +127,23 @@ jobs:
         FILE: ${{ steps.check-file-count.outputs.FILE }}
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: |
-        PATTERN='os\.exec|lfs\.rmdir|sysDataSendRequest'
+        # Nothing a package legitimately does needs these, so they are looked at by
+        # hand wherever they turn up, however long they have been in the package.
+        PATTERN_STRICT='os\.exec|lfs\.rmdir'
+        # A standard Mudlet event: registering a handler for it is how a mapper tracks
+        # movement, and it is also how a package would read everything you type. Worth
+        # a look when a pull request touches one, not worth freezing every package that
+        # has always had one - that is what made them impossible to update (#755).
+        PATTERN_CONTEXTUAL='sysDataSendRequest'
+
+        if grep -a -n -R -E "$PATTERN_STRICT" unzipped_package/; then
+          echo "::error:: questionable functions used, please validate manually"
+          exit 1
+        fi
 
         # Unpack the version of this package that is already on the base branch, so the
         # two can be compared file by file. Whatever it matched there was looked at when
         # it was merged; only what this pull request changes needs another manual look.
-        # Checking the whole package instead would freeze every package that legitimately
-        # uses one of these - handling sysDataSendRequest is how a mapper tracks
-        # movement, so those packages could never be updated again (#755).
         if git fetch --no-tags --depth=1 origin "$BASE_SHA" >/dev/null 2>&1 \
            && git cat-file -e "$BASE_SHA:$FILE" 2>/dev/null \
            && git show "$BASE_SHA:$FILE" > base_package.zip \
@@ -153,35 +162,6 @@ jobs:
             # a diff hunk covers the handler or function a match sits in, so a match shows
             # up in one when it is added, when it moves, and when the code around it is
             # rewritten. Removed lines are dropped - taking a match out needs no review.
-        PATTERN_STRICT='os\.exec|lfs\.rmdir'
-        PATTERN_CONTEXTUAL='sysDataSendRequest'
-
-        # Check for unconditionally dangerous patterns anywhere in the package.
-        if grep -q -R -a -E "$PATTERN_STRICT" unzipped_package/; then
-          echo "::error:: unconditionally dangerous functions found (os.exec, lfs.rmdir), please validate manually"
-          exit 1
-        fi
-
-        # Unpack the version of this package that is already on the base branch, so the
-        # two can be compared file by file. Whatever it matched there was looked at when
-        # it was merged; only what this pull request changes needs another manual look.
-        # Checking the whole package instead would freeze every package that legitimately
-        # uses one of these - handling sysDataSendRequest is how a mapper tracks
-        # movement, so those packages could never be updated again (#755).
-        if git fetch --no-tags --depth=1 origin "$BASE_SHA" >/dev/null 2>&1 \
-           && git cat-file -e "$BASE_SHA:$FILE" 2>/dev/null \
-           && git show "$BASE_SHA:$FILE" > base_package.zip \
-           && unzip -q -o base_package.zip -d unzipped_base_package; then
-          echo "Comparing against ${FILE} as of ${BASE_SHA}."
-        else
-          # a new package, or the previous version could not be read: check it whole
-          echo "No previous version of ${FILE} to compare against, checking the whole package."
-        fi
-
-        : > findings.txt
-        while IFS= read -r new_file; do
-          base_file="unzipped_base_package/${new_file#unzipped_package/}"
-          if [ -f "$base_file" ]; then
             hits=$(diff -a -U20 "$base_file" "$new_file" | grep -v '^-' | grep -a -E "$PATTERN_CONTEXTUAL") || true
           else
             hits=$(grep -a -E "$PATTERN_CONTEXTUAL" "$new_file") || true
@@ -194,23 +174,7 @@ jobs:
         if [ -s findings.txt ]; then
           echo "Added or changed by this pull request:"
           cat findings.txt
-          echo "::error:: questionable functions or events used, please validate manually"
-          exit 1
-        fi
-
-        echo "Pass: security checks"
-          else
-            hits=$(grep -a -E "$PATTERN" "$new_file") || true
-          fi
-          if [ -n "$hits" ]; then
-            printf '%s:\n%s\n' "${new_file#unzipped_package/}" "$hits" >> findings.txt
-          fi
-        done < <(find unzipped_package -type f)
-
-        if [ -s findings.txt ]; then
-          echo "Added or changed by this pull request:"
-          cat findings.txt
-          echo "::error:: questionable functions or events used, please validate manually"
+          echo "::error:: questionable events used, please validate manually"
           exit 1
         fi
 

--- a/.github/workflows/validate-mpackage.yml
+++ b/.github/workflows/validate-mpackage.yml
@@ -150,7 +150,10 @@ jobs:
            && unzip -q -o base_package.zip -d unzipped_base_package; then
           echo "Comparing against ${FILE} as of ${BASE_SHA}."
         else
-          # a new package, or the previous version could not be read: check it whole
+          # A new package, or a previous version that could not be read: check it whole.
+          # unzip reports a warning with a non-zero status once it has already unpacked
+          # everything, so drop what it left rather than half-comparing against it.
+          rm -rf unzipped_base_package
           echo "No previous version of ${FILE} to compare against, checking the whole package."
         fi
 
@@ -161,8 +164,16 @@ jobs:
             # Only report a match that this pull request touched: with 20 lines of context
             # a diff hunk covers the handler or function a match sits in, so a match shows
             # up in one when it is added, when it moves, and when the code around it is
-            # rewritten. Removed lines are dropped - taking a match out needs no review.
-            hits=$(diff -a -U20 "$base_file" "$new_file" | grep -v '^-' | grep -a -E "$PATTERN_CONTEXTUAL") || true
+            # rewritten. Removed lines are dropped - taking a match out needs no review -
+            # and so are the two header lines, which carry a path rather than any code.
+            changed=$(diff -a -U20 "$base_file" "$new_file") && rc=0 || rc=$?
+            if [ "$rc" -ge 2 ]; then
+              # diff says 0 for same and 1 for differs. Anything above that means it could
+              # not do the comparison, which must not pass for a file with nothing in it.
+              echo "::error:: could not compare ${new_file#unzipped_package/} against the version in ${FILE}"
+              exit 1
+            fi
+            hits=$(printf '%s\n' "$changed" | tail -n +3 | grep -v '^-' | grep -a -E "$PATTERN_CONTEXTUAL") || true
           else
             hits=$(grep -a -E "$PATTERN_CONTEXTUAL" "$new_file") || true
           fi

--- a/.github/workflows/validate-mpackage.yml
+++ b/.github/workflows/validate-mpackage.yml
@@ -123,11 +123,48 @@ jobs:
     - name: Check for malicious content
       if: steps.skip-if-deleted.outputs.skip != 'true'
       id: check-malicious-content
+      env:
+        FILE: ${{ steps.check-file-count.outputs.FILE }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: |
-        FILE="${{ steps.check-file-count.outputs.FILE }}"
-        if grep -q -R -E 'os\.exec|lfs\.rmdir|sysDataSendRequest' unzipped_package/; then
+        PATTERN='os\.exec|lfs\.rmdir|sysDataSendRequest'
+
+        # every line matching PATTERN, whitespace-normalised and sorted, so that two
+        # versions of the same package can be compared with comm
+        collect_matches() {
+          [ -d "$1" ] || return 0
+          grep -a -h -R -E "$PATTERN" "$1" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | LC_ALL=C sort
+        }
+
+        collect_matches unzipped_package > new_matches.txt
+
+        # Compare against the version of this package that is already on the base
+        # branch: whatever it matched there was looked at when it was merged, so only
+        # what this pull request introduces needs another manual look. Checking the
+        # whole package instead would freeze every package that legitimately uses one
+        # of these - handling sysDataSendRequest is how a mapper tracks movement (#755).
+        : > base_matches.txt
+        if git fetch --no-tags --depth=1 origin "$BASE_SHA" >/dev/null 2>&1 \
+           && git cat-file -e "$BASE_SHA:$FILE" 2>/dev/null \
+           && git show "$BASE_SHA:$FILE" > base_package.zip \
+           && unzip -q -o base_package.zip -d unzipped_base_package; then
+          collect_matches unzipped_base_package > base_matches.txt
+          echo "Comparing against ${FILE} as of ${BASE_SHA}."
+        else
+          # a new package, or the previous version could not be read: check it whole
+          echo "No previous version of ${FILE} to compare against, checking the whole package."
+        fi
+
+        INTRODUCED=$(LC_ALL=C comm -13 base_matches.txt new_matches.txt)
+        if [ -n "$INTRODUCED" ]; then
+          echo "Introduced by this pull request:"
+          echo "$INTRODUCED"
           echo "::error:: questionable functions or events used, please validate manually"
           exit 1
+        fi
+
+        if [ -s new_matches.txt ]; then
+          echo "Pass: security checks - every match was in the previous version of this package already"
         else
           echo "Pass: security checks"
         fi


### PR DESCRIPTION
## What this changes

`os.exec` and `lfs.rmdir` are checked exactly as before: they fail wherever they
appear, however long they have been in the package. The step now names the file
and line instead of only saying that something matched.

`sysDataSendRequest` is compared against the version of the same package already
on the base branch. It fails when this pull request adds a match, moves one, or
rewrites the code around one; a match the package has always carried, untouched
by the diff, no longer fails. That is #755: a standard Mudlet event that any
mapper registers was failing packages on content reviewed when they were merged,
so they could never be updated again.

## What stays blocked

Scanning all 224 packages: 27 carry one of the three patterns. 13 have
`sysDataSendRequest`, 17 have `os.exec` or `lfs.rmdir`, 3 have both.

**17 packages remain permanently blocked** by the unconditional patterns. Seven
of them do not call either function themselves - the match is in a library they
vendored:

| package | file | pattern |
| --- | --- | --- |
| Caffeine | `vendor/Glu-single.lua:2121` | `lfs.rmdir` |
| Carto | `Glu-single.lua:2149` | `lfs.rmdir` |
| Chatter | `Glu-single.lua:2119` | `lfs.rmdir` |
| Explorer | `Glu-single.lua:2149` | `lfs.rmdir` |
| Highlighter | `Glu-single.lua:2149` | `lfs.rmdir` |
| Muddy | `vendor/Glu-single.lua:2121` | `lfs.rmdir` |
| MudletBusted | `pl/compat.lua:48,50`, `pl/path.lua:67`, `pl/utils.lua:387` | both |

All six Glu hits are the same line of the same bundled copy. MudletBusted's are
Penlight's portability shims.

The other ten match in the package's own code. Note `os\.exec` matches
`os.execute` - Lua has no `os.exec` - so every hit below is `os.execute`:

| package | location | what it does |
| --- | --- | --- |
| ArkadiaInstaller | `ArkadiaScriptsInstaller.xml:109` | `lfs.rmdir(dir)` |
| DarkMistsCompanion | `DarkMistsCompanion.xml:4829` | `lfs.rmdir(path)`, also has `sysDataSendRequest` |
| MUDKIP_Mud2 | `MUDKIP_Mud2.xml:1001,1033` | `lfs.rmdir(defaults.temp_file_path)` |
| DSL PNP 4 | `PNP/DSL_PNP_Growl.lua:36` | `os.execute(defaults.path ..)`, also has `sysDataSendRequest` |
| ROTD_GUI | `ROTD_GUI.xml:1554,1556,1617,1625` | `os.execute('mkdir ..')`, `os.execute(cmd)` |
| cleftofdimensions | `cleftofdimensions.xml:599,600,631,632` | `os.execute("gst-launch-1.0 ..")`, mkdir; one hit is a commented-out curl |
| define-english-word-plugin | `defineWord.xml:18` | `os.execute("sleep ..")` |
| lusternia-fancy-gui | `lusternia-fancy-gui-v2.xml:714-716` | `os.execute` with open / start / xdg-open |
| mag-mudlet-aardwolf-gui | `package.xml:13` | `os.execute("aplay /usr/share/..")` |
| dartmudlet-1.11.1.zip | `_core.lua:19,27` | `os.execute("rm -r " .. folderPath)`, `rmdir /S /Q` |

Most of that is platform plumbing - make a directory, open a URL, play a sound,
delete a temporary directory. Updating any of these still needs a maintainer to
merge past a red check, exactly as today.

## What this actually unblocks

Ten packages carry `sysDataSendRequest` and nothing else: MoralDecay-GUI,
MumeSpellTimers, PetriaMapper, auto_retype, command-line-api, generic_mapper,
mudlet-base-ui, simple-mapper, stopinator, text-map-tile-map. Two of those,
generic_mapper and mudlet-base-ui, are core packages that `update-core-packages`
commits straight to main and that never run this workflow, so eight packages
gain a pull request path they did not have.

The remaining three with `sysDataSendRequest` - DSL PNP 4, DarkMistsCompanion,
dartmudlet - stay blocked by their strict match.

## Limits worth knowing

The `sysDataSendRequest` comparison uses 20 lines of diff context, so an edit
within 20 lines of a match still fails. A bugfix to `mmp_track_exits`, the
handler #755 quotes, would go red; the #754 edit that prompted the issue is 552
lines away from the match and passes.

Context also cannot follow a call. A handler whose payload lives further away,
or in another `<Script>` element, can be rewritten without the check noticing -
this is a human-review trigger rather than a security boundary.

This workflow does not run on its own pull requests (`paths:` is `packages/*`),
so nothing here is covered by CI. It was verified by extracting the step body
and replaying it against real packages.

Fixes #755 