### PR TITLE
Make the whole package readable before the checks look at it

### DIFF
--- a/.github/workflows/validate-mpackage.yml
+++ b/.github/workflows/validate-mpackage.yml
@@ -87,6 +87,23 @@ jobs:
         
         # unzip the mpackage
         unzip -q -o "${FILE}" -d unzipped_package
+
+        # An archive carries the mode of every entry it creates, and a directory
+        # stored 0111 extracts unreadable: find and grep in the malicious-content
+        # check walk straight past everything under it. Mudlet's own unzip never
+        # reads the stored mode, so it installs that subtree as normal - only the
+        # checks here are blinded. Take the modes back before anything looks.
+        chmod -R u+rwX unzipped_package
+
+        # Nothing but files and directories is a package's to ship, and a symlink
+        # is another way to show the checks one thing and Mudlet another.
+        ODD=$(find unzipped_package ! -type f ! -type d)
+        if [ -n "$ODD" ]; then
+          echo "Error: this package contains entries that are neither files nor directories:"
+          echo "$ODD" | sed 's|^unzipped_package/|  |'
+          exit 1
+        fi
+
         ls -al unzipped_package
 
         #only valid if it has a config.lua
@@ -174,6 +191,9 @@ jobs:
            && git cat-file -e "$BASE_SHA:$FILE" 2>/dev/null \
            && git show "$BASE_SHA:$FILE" > base_package.zip \
            && unzip -q -o base_package.zip -d unzipped_base_package; then
+          # Same as for the package under review: a previous version could have
+          # stored a directory unreadable, and the comparison has to see inside it.
+          chmod -R u+rwX unzipped_base_package
           echo "Comparing against ${FILE} as of ${BASE_SHA}."
         else
           # A new package, or a previous version that could not be read: check it whole.


### PR DESCRIPTION
Fixes #777.

A zip carries the mode of every entry it creates and `unzip` applies it, so a package whose scripts live under a directory entry stored `0111` extracts as `d--x--x--x`. `find` and `grep -R` in `check-malicious-content` cannot enumerate it, and the subtree is invisible to the gate. Mudlet's own `mudlet::unzip` never reads the stored mode — it makes directories with `mkpath` and files with `QFile::open` — so the package installs readable and runs. Only CI was blind, and `auto-merge-packages.yml` gates on this job.

- `chmod -R u+rwX unzipped_package` right after extraction in `unzip-mpackage-file`, and the same for `unzipped_base_package` in `check-malicious-content` so the file-by-file comparison against the previous version can see inside it too.
- An entry that is neither a file nor a directory now fails the step. A symlink is the same trick by another route — `find -type f` skips it while Mudlet installs whatever it names — and nothing a package legitimately ships needs one.

## Testing

Ran the step body as it stands on this branch, in WSL Ubuntu, against three archives built by the issue's repro script:

| package | before | after |
| --- | --- | --- |
| `scripts/` stored `0111`, holding `os.execute`, `lfs.rmdir`, `sysDataSendRequest` | `find` reports `Permission denied`, malicious-content grep finds nothing, **passes** | subtree readable, all three patterns match, **blocked** |
| a symlink entry `link -> /etc/passwd` | extracted, invisible to `find -type f` | step exits 1: `entries that are neither files nor directories: link` |
| an ordinary package | passes | passes |

The file parses as YAML and every `run:` block passes `bash -n`. The workflow only triggers on `packages/*`, so it does not run on this pull request.

Touches the same step as #784 (the `${{ }}` filename fix for #778); whichever lands second needs a trivial rebase.

https://claude.ai/code/session_01EmWdhTzNHjTmc15J9fMeLM
