### PR TITLE
Register arkadia-mpackage trusted publisher (ishtar_cal, imperium_cal, pasek_kalendarz_arkadia)

### DIFF
--- a/trusted-publishers.json
+++ b/trusted-publishers.json
@@ -18,6 +18,33 @@
       "repositoryId": "80291515",
       "repositoryOwnerId": "1749428",
       "workflow": ".github/workflows/publish-package-repository.yml"
+    },
+    {
+      "mpackage": "ishtar_cal",
+      "filename": "ishtar_cal.mpackage",
+      "repository": "Isithunzi000/arkadia-mpackage",
+      "repositoryId": "1346062051",
+      "repositoryOwnerId": "263814053",
+      "workflow": ".github/workflows/sync-publish.yml",
+      "ref": "refs/heads/main"
+    },
+    {
+      "mpackage": "imperium_cal",
+      "filename": "imperium_cal.mpackage",
+      "repository": "Isithunzi000/arkadia-mpackage",
+      "repositoryId": "1346062051",
+      "repositoryOwnerId": "263814053",
+      "workflow": ".github/workflows/sync-publish.yml",
+      "ref": "refs/heads/main"
+    },
+    {
+      "mpackage": "pasek_kalendarz_arkadia",
+      "filename": "pasek_kalendarz_arkadia.mpackage",
+      "repository": "Isithunzi000/arkadia-mpackage",
+      "repositoryId": "1346062051",
+      "repositoryOwnerId": "263814053",
+      "workflow": ".github/workflows/sync-publish.yml",
+      "ref": "refs/heads/main"
     }
   ]
 }


### PR DESCRIPTION
Register three Mudlet calendar packages for trusted publishing from `Isithunzi000/arkadia-mpackage`:

- `ishtar_cal` — game-time calendar for the Ishtar domain (Arkadia MUD)
- `imperium_cal` — game-time calendar for the Imperium domain
- `pasek_kalendarz_arkadia` — shared calendar status bar

Notes for review:

- The publishing workflow lives at `.github/workflows/sync-publish.yml` on `main` of the named repository; each entry is additionally pinned to `refs/heads/main`.
- Ids were read with `curl -s https://api.github.com/repos/Isithunzi000/arkadia-mpackage | jq '.id, .owner.id'` (repositoryId 1346062051, repositoryOwnerId 263814053).
- The workflow syncs new upstream releases, attaches the required `created` field to `config.lua` in a deterministic build, attaches the variant to a release of the publishing repository, and calls `/api/publish` with the release asset URL. `validate-trusted-publishers.mjs` passes locally on this change (`4 publisher(s), all valid`).