### PR TITLE
Index main's tip instead of the commit that asked for the refresh

### DIFF
--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -54,7 +54,10 @@ jobs:
     # them.
     - name: Cache luarocks modules
       id: luarocks-cache
-      uses: actions/cache@v4
+      # Pinned by commit, not tag: a tag is a pointer its owner can move, and this job
+      # holds a token that can write to main. Dependabot bumps the SHA and the comment
+      # together when a new release lands.
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           .luarocks

--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -32,7 +32,12 @@ jobs:
       with:
         fetch-depth: 0
 
+    # Pinned so the cache key below can name the interpreter the rocks were compiled
+    # against. Left to the action, a new default would move us to a different Lua ABI
+    # without changing anything the key can see.
     - uses: leafo/gh-actions-lua@v10
+      with:
+        luaVersion: "5.4"
 
     - uses: leafo/gh-actions-luarocks@v4
   
@@ -42,7 +47,11 @@ jobs:
       run: sudo apt-get install -y libzzip-dev libyajl-dev
 
     # Building these takes two minutes for a two-second indexing job, and the tree ages
-    # the whole time. The key covers this file, so changing the rock list rebuilds them.
+    # the whole time. The key covers this file, so changing the rock list rebuilds them,
+    # plus everything luazip and lua-yajl are compiled against: the runner image and the
+    # Lua version. A hit skips the install step below, so a restore that does not match
+    # the runner would hand reindex.lua modules it cannot load, with nothing to rebuild
+    # them.
     - name: Cache luarocks modules
       id: luarocks-cache
       uses: actions/cache@v4
@@ -50,7 +59,7 @@ jobs:
         path: |
           .luarocks
           ~/.luarocks
-        key: luarocks-${{ runner.os }}-${{ hashFiles('.github/workflows/create-package-index.yml') }}
+        key: luarocks-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-lua5.4-${{ hashFiles('.github/workflows/create-package-index.yml') }}
 
     - name: Install luarocks modules
       if: steps.luarocks-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -7,11 +7,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:    
 
-# Two runs indexing at once is last-writer-wins on a stale tree: each one regenerates the
-# index from the packages it checked out, and whichever pushes second wins with whatever
-# it saw. Queue them instead.
+# Every merge asks for its own refresh, and the index is a pure function of the packages
+# on main: an older run has nothing to say that the newer one won't say too. Cancel it
+# rather than pay for it twice.
 concurrency:
   group: package-index
+  cancel-in-progress: true
 
 jobs:
   reindex-json-file:
@@ -25,19 +26,34 @@ jobs:
       issues: write
 
     steps:
+    # No ref: the publish step below indexes main's tip as of the moment it runs, not
+    # whichever commit happened to trigger this run.
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref }}
         fetch-depth: 0
 
     - uses: leafo/gh-actions-lua@v10
 
     - uses: leafo/gh-actions-luarocks@v4
   
+    # Needed whether or not the rocks come from the cache: the compiled modules link
+    # against these at runtime.
     - name: Install apt dependencies
       run: sudo apt-get install -y libzzip-dev libyajl-dev
 
+    # Building these takes two minutes for a two-second indexing job, and the tree ages
+    # the whole time. The key covers this file, so changing the rock list rebuilds them.
+    - name: Cache luarocks modules
+      id: luarocks-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          .luarocks
+          ~/.luarocks
+        key: luarocks-${{ runner.os }}-${{ hashFiles('.github/workflows/create-package-index.yml') }}
+
     - name: Install luarocks modules
+      if: steps.luarocks-cache.outputs.cache-hit != 'true'
       run: |
         luarocks install json-lua
         luarocks install luazip
@@ -45,24 +61,53 @@ jobs:
         luarocks install lua-yajl YAJL_LIBDIR=`find /usr -name "libyajl.so" -printf '%h\n'` YAJL_INCDIR=/usr/include
 
 
-    # Fix timestamps
+    # Fix timestamps: the index dates each package by its file mtime, which a fresh
+    # checkout would otherwise report as today for every one of them.
     - name: restore timestamps
       uses: chetan/git-restore-mtime-action@v2
 
-    - name: Run indexing
+    - name: Publish the refreshed index
       run: |
-        lua reindex.lua
+        set -euo pipefail
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-    # Commit all changed files back to the repository
-    - uses: stefanzweifel/git-auto-commit-action@v5        
-      with:
-        commit_message: Automated package index update.
-        file_pattern: 'packages/*.packages.json packages/icons/*'
+        for attempt in 1 2 3; do
+          # Index what is on main now. Everything above this line takes minutes, and
+          # packages merge while it runs, so the checkout is routinely behind by the
+          # time we get here. Only the files that actually differ are rewritten, so
+          # the restored mtimes survive for every package that did not just land.
+          git fetch --quiet origin main
+          git reset --quiet --hard origin/main
+
+          lua reindex.lua
+
+          git add -A -- 'packages/*.packages.json' 'packages/icons'
+          if git diff --cached --quiet; then
+            echo "Index already matches the packages on main; nothing to publish."
+            exit 0
+          fi
+
+          git commit --quiet -m 'Automated package index update.'
+
+          if git push --quiet origin HEAD:main; then
+            echo "Published the refreshed index."
+            exit 0
+          fi
+
+          # Something landed on main between the fetch and the push. Whatever it is has
+          # to stay, so drop our commit and index the new tip instead of forcing.
+          echo "main moved while publishing (attempt ${attempt}); re-indexing its new tip."
+        done
+
+        echo "Could not publish the index: main kept moving across 3 attempts." >&2
+        exit 1
 
     # The workflows that ask for a refresh cannot see how it went, and a run that fails
-    # here leaves mpkg offering whatever the listing said before.
+    # here leaves mpkg offering whatever the listing said before. A cancelled run is not
+    # worth reporting: it was superseded by a newer refresh that covers the same packages.
     - name: Report a refresh that failed
-      if: failure() || cancelled()
+      if: failure()
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Closes #791.

## The failures

Both runs linked from #791 built the index fine and died on the push:

```
! [rejected]  main -> main (non-fast-forward)
```

The step timings explain why. A refresh takes ~2m40s, of which **2m06s is `luarocks install`** and **2 seconds is the actual indexing**:

| Step | Duration |
|---|---|
| checkout | 7s |
| lua + luarocks setup | 20s |
| `luarocks install` | 2m 06s |
| restore timestamps + `reindex.lua` | 2s |
| commit + push | 2s |

The checkout SHA is frozen when the run is *created*, so a run dispatched at 13:31 but started at 13:34 (queued behind another) indexes a three-minute-old tree and then compiles for two more minutes before pushing. Three package PRs merged inside twelve minutes on 2026-08-25, and two refreshes lost the race.

`concurrency: package-index` didn't help: it serializes refreshes against each other, but the commits that move `main` are PR merges, which push directly and aren't in the group.

## The changes

1. **Index the tip, not the trigger SHA.** `git fetch origin main && git reset --hard origin/main` runs *after* the slow install, immediately before indexing. The stale window goes from ~160s to the ~4s between fetch and push. `reset --hard` only rewrites files that actually differ, so the restored mtimes survive for every package that didn't just land — and the index dates packages by mtime. Dropped `ref: ${{ github.head_ref }}` from the checkout, which was empty for both triggers anyway and now reads as a promise the publish step doesn't keep.

2. **Re-index and retry instead of reporting.** On a rejected push, drop the commit, sync to the new tip and index again, up to three attempts. Never forces — whatever merged has to stay. This is strictly better than the old success path too: a package that lands mid-run is published immediately rather than waiting for the next push to notice it.

3. **Cache the rocks**, keyed on OS plus a hash of this workflow, with the install skipped on a hit. The apt step stays unconditional: the cached `.so` files link against `libyajl`/`libzzip` at runtime. Expect ~2m40s → ~35s.

4. **`cancel-in-progress: true`**, and `cancelled()` dropped from the reporter. Every merge dispatches its own refresh and the index is a pure function of the packages on `main`, so an older run has nothing to add. Three merges in twelve minutes now cost one run instead of three. Without the reporter change, each cancellation would comment on #791.

## Testing

`bash -n` on the publish script; the workflow YAML parsed and its step graph inspected. Lua isn't available locally, so I ran the publish loop verbatim against a throwaway origin with `reindex.lua` stubbed out, injecting a competing merge between indexing and pushing:

| Race | Result |
|---|---|
| none | publishes, exit 0 |
| one merge mid-run | attempt 1 rejected → attempt 2 publishes an index **containing the package that landed during the run**, exit 0 |
| main never stops moving | 3 attempts, exit 1, no force-push, every competing commit intact, reporter fires |

The middle row is the #791 scenario.

## Adjacent gap, not fixed here

`muddle-mpkg.yml` commits `packages/mpkg.mpackage` using `GITHUB_TOKEN`, which can't fire this workflow's `push` trigger, and unlike `auto-merge-packages.yml` and `update-core-packages.yml` it doesn't dispatch a refresh. A rebuilt mpkg is therefore only indexed when an unrelated push comes along. Pre-existing and separate; happy to fix it in its own PR.

https://claude.ai/code/session_01YNijsyzb2r1S2bJVMRtfVG
