### PR TITLE
Date packages by their git history, not by their file mtime

### DIFF
--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -27,7 +27,8 @@ jobs:
 
     steps:
     # No ref: the publish step below indexes main's tip as of the moment it runs, not
-    # whichever commit happened to trigger this run.
+    # whichever commit happened to trigger this run. The full history is what dates the
+    # packages -- reindex.lua asks git when each one last changed.
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -73,11 +74,6 @@ jobs:
         luarocks install lua-yajl YAJL_LIBDIR=`find /usr -name "libyajl.so" -printf '%h\n'` YAJL_INCDIR=/usr/include
 
 
-    # Fix timestamps: the index dates each package by its file mtime, which a fresh
-    # checkout would otherwise report as today for every one of them.
-    - name: restore timestamps
-      uses: chetan/git-restore-mtime-action@v2
-
     - name: Publish the refreshed index
       run: |
         set -euo pipefail
@@ -87,8 +83,7 @@ jobs:
         for attempt in 1 2 3; do
           # Index what is on main now. Everything above this line takes minutes, and
           # packages merge while it runs, so the checkout is routinely behind by the
-          # time we get here. Only the files that actually differ are rewritten, so
-          # the restored mtimes survive for every package that did not just land.
+          # time we get here.
           git fetch --quiet origin main
           git reset --quiet --hard origin/main
 

--- a/reindex.lua
+++ b/reindex.lua
@@ -40,12 +40,39 @@ local function urlEncode(str)
   return str:gsub("[^%w]", encodeChars)
 end
 
-local function getFileModTime(filepath)
-    local attr = lfs.attributes(filepath)
-    if attr and attr.mode == "file" then
-        return attr.modification
+-- When each package landed, according to git rather than to the filesystem. A checkout
+-- has no upload dates to report: git writes every file at clone time, so dating packages
+-- by their mtime makes the entire repository look like it was uploaded today.
+local function readUploadTimes()
+    local times = {}
+
+    -- One walk of the history, newest first, so the first commit that names a path is the
+    -- one that last touched it. --first-parent -m dates a package by the commit that
+    -- brought it into this branch, which for a merged pull request is the merge itself and
+    -- not whenever the branch happened to be written. quotePath off keeps non-ASCII
+    -- filenames spelled the way the package loop below sees them, rather than as escapes.
+    local out = io.popen("git -c core.quotePath=false log --first-parent -m --format=@%ct --name-only -- packages")
+    if not out then return times end
+
+    local commitTime
+    for line in out:lines() do
+        local timestamp = line:match("^@(%d+)$")
+        if timestamp then
+            commitTime = tonumber(timestamp)
+        elseif commitTime and line ~= "" and not times[line] then
+            times[line] = commitTime
+        end
     end
-    return os.time() -- fallback to current time if we can't get the file time
+    out:close()
+
+    return times
+end
+
+local uploadTimes = readUploadTimes()
+
+local function getUploadTime(filepath)
+    -- Not committed yet: a package the history has never seen is as new as it gets.
+    return uploadTimes[filepath] or os.time()
 end
 
 local function clearPackageVariables()
@@ -121,7 +148,7 @@ for file in io.popen("ls -pa packages/*"):lines() do
             ["description"] = description,
             ["created"] = created,
             ["version"] = version,
-            ["uploaded"] = getFileModTime(file),
+            ["uploaded"] = getUploadTime(file),
             ["filename"] = file:gsub("packages/", ""),
             ["icon"] = iconUrl
         })


### PR DESCRIPTION
`reindex.lua` dated each package by the mtime of its `.mpackage` file, which a checkout does not carry: git writes every file at clone time. The workflow papered over that with `git-restore-mtime`, and it held until #792 added a `git reset --hard origin/main` *after* the restore step.

`reset --hard` re-checks-out every entry whose cached stat data no longer matches the working tree, and rewriting mtimes is precisely what invalidates that cache — content equality does not save them:

```
touch -d 2020-01-01 f.txt; git reset --hard HEAD   -> mtime = now        (clobbered)
touch -d 2020-01-01 f.txt; git update-index --refresh
                           git reset --hard HEAD   -> mtime = 2020-01-01 (survives)
```

Both refreshes since then stamped all 229 packages with the run's own clock (`41de080`, `0d09eb1` — 230 and 232 changed lines against the 1–21 a normal refresh touches). Every `uploaded` in the published index is now the same number, two seconds before its commit, so mpkg is telling users the entire repository was uploaded today.

## The fix

Ask git when each package last changed, instead of asking the filesystem:

```
git -c core.quotePath=false log --first-parent -m --format=@%ct --name-only -- packages
```

One walk of the history, newest first, so the first commit naming a path is the one that last touched it — and no later step can undo it. `--first-parent -m` dates a package by the commit that brought it onto `main` rather than by whenever its branch was written, which is what "uploaded" means to someone waiting for a release: the day the package became available, not the day its author started on it. A path git has never seen falls back to `os.time()`, which is right for a package indexed before it is committed.

The `restore timestamps` step comes out with it. `fetch-depth: 0` stays — it is now what `git log` reads.

## Verified

Ran the new function under Lua 5.4 against this repo:

- 304 paths dated; all 229 indexed packages found in git, none fell back
- **217 of 229 reproduce the pre-regression values exactly**
- the 12 that differ are all author-date vs committer-date, which is what `git-restore-mtime` read. Eleven move by seconds to hours. The twelfth, `mudlet-base-ui`, moves 22 days forward to the day it actually merged — the old scheme dated it to before it existed here.
- `luac -p` clean; the uncommitted-file fallback returns now

No backfill needed for the 229 flattened timestamps: every entry is recomputed from history, so the next refresh restores them.

https://claude.ai/code/session_01428ic2fs1MHBHpfzCBFwT2