### PR TITLE
Check for bundled package updates every six hours

### DIFF
--- a/.github/workflows/update-core-packages.yml
+++ b/.github/workflows/update-core-packages.yml
@@ -13,7 +13,11 @@ name: Update core packages
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * fri'
+    # Every six hours. A run costs six conditional downloads and commits only when
+    # something actually moved upstream, so the cost of checking often is close to
+    # nothing - and it caps how long mpkg serves an older copy than Mudlet ships at
+    # six hours rather than a week.
+    - cron: '0 */6 * * *'
 
 permissions:
   contents: write
@@ -108,5 +112,5 @@ jobs:
             gh issue comment "$existing" --body "Failed again: ${RUN_URL}"
           else
             gh issue create --title "$title" \
-              --body "The weekly sync of the packages Mudlet bundles did not finish, so mpkg may be serving older copies than Mudlet ships: ${RUN_URL}"
+              --body "The sync of the packages Mudlet bundles did not finish, so mpkg may be serving older copies than Mudlet ships: ${RUN_URL}"
           fi


### PR DESCRIPTION
Changes the `Update core packages` schedule from weekly to every six hours.

```diff
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * fri'
+    - cron: '0 */6 * * *'
```

### Why

The six packages Mudlet bundles are edited in Mudlet's repository, not this one, and this job is what brings the copies mpkg serves in line with them. Running weekly means a package edited just after a Friday run spends nearly seven days with mpkg still offering the previous version.

Nothing about the job wants that gap. It downloads six archives and compares, then `git status --porcelain -- packages` decides whether there is anything to commit — so on a run where Mudlet's development branch has not moved, it commits nothing, pushes nothing, and does not dispatch the index refresh. The cost of asking four times a day instead of once a week is six conditional downloads per run.

Six hours also lines the cadence up with how the packages are actually produced: they land on Mudlet's `development` continuously, not on a weekly boundary.

### Notes

- `workflow_dispatch` stays, for when six hours is still too long to wait.
- The failure report no longer calls itself "the weekly sync". It still reuses one open `Core package sync is failing` issue and comments on it rather than opening a new one, so a sustained upstream outage produces up to four comments a day on a single issue instead of one a week — noisier during a real outage, but still deduplicated.
- No change to what is fetched, how it is validated (`unzip -p ... config.lua` before the archive is moved into place), or the commit-to-`main` behaviour.

Verified the file still parses and the trigger is what it should be: `{'workflow_dispatch': None, 'schedule': [{'cron': '0 */6 * * *'}]}`, all 6 steps intact. The cron fires at 00:00, 06:00, 12:00 and 18:00 UTC.

Assisted-by: Claude:claude-opus-5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BunLQfit1CBGXsYtaf4EME)_