### PR TITLE
Register Exchange Walker trusted publisher

### DIFF
--- a/trusted-publishers.json
+++ b/trusted-publishers.json
@@ -45,6 +45,14 @@
       "repositoryOwnerId": "263814053",
       "workflow": ".github/workflows/sync-publish.yml",
       "ref": "refs/heads/main"
+    },
+    {
+      "mpackage": "exchange-walker-live",
+      "filename": "exchange-walker-live.mpackage",
+      "repository": "ralphcma/fed2-exchange-walker-live",
+      "repositoryId": "1344569891",
+      "repositoryOwnerId": "65855516",
+      "workflow": ".github/workflows/publish.yml"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Registers the release workflow in `ralphcma/fed2-exchange-walker-live` as the trusted publisher for `exchange-walker-live`.

The package uses the stable destination `exchange-walker-live.mpackage`. Its first trusted publish will intentionally rename the historical `exchange-walker-live-3.0.0-live.mpackage` archive, so that first package-update PR will require manual maintainer review as documented.

## Verification

- repository ID: `1344569891`
- repository owner ID: `65855516`
- workflow: `.github/workflows/publish.yml`
- publisher workflow commit: `bf5e2cf17beb58d2d4ddb8d7ad4201e0af373a68`
- `node .github/scripts/validate-trusted-publishers.mjs`: 5 publishers, all valid
- no `ref` restriction is set because the workflow runs from release tag refs