### PR TITLE
Register MudletSTT and MudletMCVP as trusted publishers

### DIFF
--- a/trusted-publishers.json
+++ b/trusted-publishers.json
@@ -53,6 +53,24 @@
       "repositoryId": "1344569891",
       "repositoryOwnerId": "65855516",
       "workflow": ".github/workflows/publish.yml"
+    },
+    {
+      "mpackage": "STT",
+      "filename": "STT.mpackage",
+      "repository": "mpconley/MudletSTT",
+      "repositoryId": "1341197754",
+      "repositoryOwnerId": "3058178",
+      "workflow": ".github/workflows/release.yml",
+      "ref": "refs/heads/main"
+    },
+    {
+      "mpackage": "MCVP",
+      "filename": "MCVP.mpackage",
+      "repository": "mpconley/MudletMCVP",
+      "repositoryId": "1335536631",
+      "repositoryOwnerId": "3058178",
+      "workflow": ".github/workflows/release.yml",
+      "ref": "refs/heads/main"
     }
   ]
 }


### PR DESCRIPTION
Adds trusted-publishing entries for two packages, per `TRUSTED-PUBLISHING.md`. Both already attach their `.mpackage` to a GitHub release; both now publish from `.github/workflows/release.yml`, which is on `main` in each repository as of today.

| | STT | MCVP |
| --- | --- | --- |
| Repository | [mpconley/MudletSTT](https://github.com/mpconley/MudletSTT) | [mpconley/MudletMCVP](https://github.com/mpconley/MudletMCVP) |
| `repositoryId` | `1341197754` | `1335536631` |
| `repositoryOwnerId` | `3058178` | `3058178` |
| Workflow | [`.github/workflows/release.yml`](https://github.com/mpconley/MudletSTT/blob/main/.github/workflows/release.yml) | [`.github/workflows/release.yml`](https://github.com/mpconley/MudletMCVP/blob/main/.github/workflows/release.yml) |

Neither package is published to this repository yet, so these are first-time additions rather than changes to who publishes an existing package. Both `filename` values match their own `mpackage` and collide with nothing already here.

**Why the publish step is in `release.yml` rather than its own file.** The documented example triggers on `release: published`, which does not work for these two: `release.yml` creates the release with `ncipollo/release-action` and the default `GITHUB_TOKEN`, and GitHub deliberately does not trigger further workflows from `GITHUB_TOKEN`-generated events — so a separate publish workflow would never fire, silently. Keeping the job in `release.yml` also keeps `job_workflow_ref` naming the file the entries pin.

**Why it is guarded.** `release.yml` runs on every push to `main` with `allowUpdates: true`. Unguarded, that would open a pull request here on every commit. A step ahead of the release checks whether a release already exists for the version in `mfile` and skips publishing when it does, so a publish happens exactly when the version is bumped.

Both entries set the optional `ref` to `refs/heads/main`, since neither workflow runs anywhere else.

Assisted-by: Claude:claude-opus-5