### PR TITLE
Tell a refused push apart from a lost race when publishing the index

### DIFF
--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -80,6 +80,10 @@ jobs:
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
+        # git push explains itself on stderr, and only one of the things it can say is
+        # worth another attempt. Keep the message so the retry can tell them apart.
+        push_error=$(mktemp)
+
         for attempt in 1 2 3; do
           # Index what is on main now. Everything above this line takes minutes, and
           # packages merge while it runs, so the checkout is routinely behind by the
@@ -97,9 +101,18 @@ jobs:
 
           git commit --quiet -m 'Automated package index update.'
 
-          if git push --quiet origin HEAD:main; then
+          if git push --quiet origin HEAD:main 2>"${push_error}"; then
             echo "Published the refreshed index."
             exit 0
+          fi
+          cat "${push_error}" >&2
+
+          # A branch that will not take a direct push from this token will not take one
+          # on the next two attempts either, and reporting that as contention sends
+          # whoever reads the issue hunting for a race that never happened.
+          if grep -qE 'GH006|protected branch' "${push_error}"; then
+            echo "Could not publish the index: main refused a direct push from github-actions[bot]. Branch protection has to let it bypass the pull request requirement." >&2
+            exit 1
           fi
 
           # Something landed on main between the fetch and the push. Whatever it is has

--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -111,7 +111,7 @@ jobs:
           # on the next two attempts either, and reporting that as contention sends
           # whoever reads the issue hunting for a race that never happened.
           if grep -qE 'GH006|protected branch' "${push_error}"; then
-            echo "Could not publish the index: main refused a direct push from github-actions[bot]. Branch protection has to let it bypass the pull request requirement." >&2
+            echo "Could not publish the index: branch protection on main rejected the push from github-actions[bot], for the reason given above. Retrying cannot settle that one." >&2
             exit 1
           fi
 

--- a/.github/workflows/create-package-index.yml
+++ b/.github/workflows/create-package-index.yml
@@ -80,8 +80,8 @@ jobs:
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-        # git push explains itself on stderr, and only one of the things it can say is
-        # worth another attempt. Keep the message so the retry can tell them apart.
+        # git push says on stderr why it was refused, and exactly one of its answers is
+        # worth another attempt. Keep the message so the loop can tell them apart.
         push_error=$(mktemp)
 
         for attempt in 1 2 3; do
@@ -101,17 +101,25 @@ jobs:
 
           git commit --quiet -m 'Automated package index update.'
 
-          if git push --quiet origin HEAD:main 2>"${push_error}"; then
+          push_status=0
+          git push --quiet origin HEAD:main 2>"${push_error}" || push_status=$?
+          # a push that succeeded still carries the remote's notices - deprecations,
+          # quota warnings - on this channel, so this is not only the failure path
+          cat "${push_error}" >&2
+
+          if [ "${push_status}" -eq 0 ]; then
             echo "Published the refreshed index."
             exit 0
           fi
-          cat "${push_error}" >&2
 
-          # A branch that will not take a direct push from this token will not take one
-          # on the next two attempts either, and reporting that as contention sends
-          # whoever reads the issue hunting for a race that never happened.
-          if grep -qE 'GH006|protected branch' "${push_error}"; then
-            echo "Could not publish the index: branch protection on main rejected the push from github-actions[bot], for the reason given above. Retrying cannot settle that one." >&2
+          # Only losing a race to another push is worth going round again, and that
+          # reaches us under three spellings: main was already ahead when this push
+          # started ("[rejected] ... fetch first"), or it moved during the push itself
+          # ("incorrect old value provided", "cannot lock ref"). Anything else - branch
+          # protection, a ruleset, a token that can no longer write - turns down the next
+          # two attempts identically, so let the remote's words above stand and stop.
+          if ! grep -qE '! \[rejected\]|incorrect old value provided|cannot lock ref' "${push_error}"; then
+            echo "Could not publish the index: the push was refused for the reason above, which retrying cannot settle." >&2
             exit 1
           fi
 
@@ -138,5 +146,5 @@ jobs:
           gh issue comment "$existing" --body "Failed again: ${RUN_URL}"
         else
           gh issue create --title "$title" \
-            --body "packages/mpkg.packages.json was not regenerated, so mpkg is still offering the versions it listed before. Re-running this workflow republishes it: ${RUN_URL}"
+            --body "packages/mpkg.packages.json was not regenerated, so mpkg is still offering the versions it listed before. The run log says which it was: a refresh that lost a race republishes on a re-run, one the remote refused needs its cause fixed first. ${RUN_URL}"
         fi


### PR DESCRIPTION
## What

The index publish step retries its push three times, because packages merge while the index builds and `main` is routinely ahead by the time we get there. But *every* rejection was read as that race — including ones no amount of retrying can settle.

When branch protection started requiring pull requests on `main`, the bot's direct push was rejected:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

The loop retried it twice more and concluded:

```
main moved while publishing (attempt 3); re-indexing its new tip.
Could not publish the index: main kept moving across 3 attempts.
```

That sent whoever opened #816 looking for contention that never happened.

## Change

Retry the one refusal another attempt can settle, and treat everything else as terminal — an allow-list rather than a deny-list, so new refusal codes are terminal by default instead of silently rejoining the race path.

Losing a race reaches us three ways: `main` already ahead at ref discovery (`! [rejected] ... fetch first`), or moving during the push itself (`incorrect old value provided`, `cannot lock ref`). Everything else — `GH006` branch protection, `GH013` rulesets, a 403 from a token that can no longer write — stops immediately, with the remote's own words as the reason:

```
Could not publish the index: the push was refused for the reason above,
which retrying cannot settle.
```

Two things came along with it:

- **stderr is now relayed on success too.** The capture had been on the success path as well, which returned before printing it — dropping the remote's deprecation and quota notices. The exit status is captured so the `cat` happens either way.
- **The filed issue no longer promises a re-run fixes it.** That is true for a race and false for a refusal, and the issue is the artifact a maintainer actually opens.

## Testing

Both against fixtures and against real pushes to local bare repos.

| stderr | expected | result |
|---|---|---|
| `[rejected] ... fetch first` (real race) | retry | ✅ |
| `incorrect old value provided` (real mid-push race) | retry | ✅ |
| `cannot lock ref ...` | retry | ✅ |
| `GH013` ruleset (real `pre-receive` refusal) | stop | ✅ |
| `GH006` protected branch (verbatim from run 33837376368) | stop | ✅ |
| `403 denied to github-actions[bot]` | stop | ✅ |
| success carrying `remote:` notices | publish, notices relayed | ✅ |
| success, empty stderr | publish | ✅ |

The harness is extracted from the workflow file itself rather than retyped, so it cannot drift from the code under test.

End-to-end, a `pre-push` hook lands a competing commit mid-push to force a genuine race:

```
 ! [remote rejected] HEAD -> main (incorrect old value provided)
main moved while publishing (attempt 1); re-indexing its new tip.
Published the refreshed index.
```

That case is why the match is not just `[rejected]`: a race lost *during* the push is reported as a **remote** rejection, so the narrower pattern I first wrote would have called a real race terminal. It only showed up by running it.

## Notes

- The underlying protection problem from #816 is already fixed separately: `github-actions` is in the bypass allowances for `main`, and [run 33897552467](https://github.com/Mudlet/mudlet-package-repository/actions/runs/33897552467) published the index (c4012b4). This PR is about the diagnosis.
- The luarocks cache key hashes this workflow file, so the first run after merge rebuilds the rocks once (~2 min).
- Review finding 7 (the "nothing to publish" success message masking a zero-package run) is pre-existing and filed separately as #824 rather than folded in here.

https://claude.ai/code/session_017ceTWJ5aY6UNKBQcMhtueg
