### PR TITLE
Retry core package downloads that fail mid-transfer

### DIFF
--- a/.github/workflows/update-core-packages.yml
+++ b/.github/workflows/update-core-packages.yml
@@ -45,7 +45,10 @@ jobs:
             # output file before it knows the response. Reading config.lua back out
             # rejects anything that is not the archive we asked for - nothing else
             # inspects these before they reach main
-            if curl -fsSL --retry 3 \
+            # --retry-all-errors as well as --retry: bare --retry covers timeouts and 5xx,
+            # but raw.githubusercontent.com also drops connections mid-transfer, and a
+            # reset that goes unretried reads downstream as the package having moved
+            if curl -fsSL --retry 3 --retry-all-errors \
                  "https://raw.githubusercontent.com/Mudlet/Mudlet/development/src/packages/${package}/${package}.mpackage" \
                  -o "${archive}.new" \
                && unzip -p "${archive}.new" config.lua > /dev/null 2>&1; then


### PR DESCRIPTION
## What

`curl --retry` does less than the name suggests: it covers timeouts and 5xx responses, but **not** a connection that drops partway through a transfer. `raw.githubusercontent.com` does that often enough to matter on a six-hourly schedule.

One did, in [run 33893835667](https://github.com/Mudlet/mudlet-package-repository/actions/runs/33893835667):

```
curl: (35) Recv failure: Connection reset by peer
```

`--retry 3` did not retry it. The `echo` package was recorded as unfetched, and the step turned that into:

```
::error::could not fetch: echo - moved in Mudlet's repository?
```

which is what #818 was opened about — a question about upstream layout that had nothing to do with what went wrong. All six upstream URLs returned 200 before and after, and `echo.mpackage` unzips with a valid `config.lua`.

## Change

Add `--retry-all-errors`, which widens the retry to transport failures like this one. Available since curl 7.71.0; `ubuntu-latest` ships 8.x.

## Notes

The step's `moved in Mudlet's repository?` wording is still a guess rather than a diagnosis, but with transient resets now retried it is a much better one, so I left it alone. Happy to reword it if you'd rather it hedged.

Companion to #819, which fixes the equivalent misleading message in the index workflow.

## Testing

`bash -n` on the extracted fetch script; confirmed the flag is accepted by curl. The retry path only shows up under a real network fault, so there is nothing deterministic to assert on — the next scheduled run exercises the normal path.

https://claude.ai/code/session_01MECYR6r8hjbTDt2FbpEnaq