### PR TITLE
Register AchaeaBeckon for trusted publishing

### DIFF
--- a/trusted-publishers.json
+++ b/trusted-publishers.json
@@ -71,6 +71,14 @@
       "repositoryOwnerId": "3058178",
       "workflow": ".github/workflows/release.yml",
       "ref": "refs/heads/main"
+    },
+    {
+      "mpackage": "AchaeaBeckon",
+      "filename": "AchaeaBeckon.mpackage",
+      "repository": "PrincessSiren/achaea-beckon",
+      "repositoryId": "1363383989",
+      "repositoryOwnerId": "48842744",
+      "workflow": ".github/workflows/release.yml"
     }
   ]
 }


### PR DESCRIPTION
AchaeaBeckon is a beckon whitelist for Achaea: it watches for someone beckoning you and sends FOLLOW only for a name on a list you wrote yourself, printing a red line and sending nothing for anyone else.

  https://github.com/PrincessSiren/achaea-beckon

The workflow builds the .mpackage from the tag, checks the tag against M.VERSION in the source, attaches it to the release and then publishes. It is release.yml rather than a publish.yml because the publish step has to sit in the workflow the registry pins, and because a release-published trigger would race the upload.

The archive is byte-reproducible across machines, so the digest recorded under provenance/ can be checked by rebuilding the tag.