### PR TITLE
Add trusted publisher: truwer (Isithunzi000/arkadia-mpackage)

### DIFF
--- a/trusted-publishers.json
+++ b/trusted-publishers.json
@@ -47,6 +47,15 @@
       "ref": "refs/heads/main"
     },
     {
+      "mpackage": "truwer",
+      "filename": "truwer.mpackage",
+      "repository": "Isithunzi000/arkadia-mpackage",
+      "repositoryId": "1346062051",
+      "repositoryOwnerId": "263814053",
+      "workflow": ".github/workflows/sync-publish.yml",
+      "ref": "refs/heads/main"
+    },
+    {
       "mpackage": "exchange-walker-live",
       "filename": "exchange-walker-live.mpackage",
       "repository": "ralphcma/fed2-exchange-walker-live",


### PR DESCRIPTION
Registers `truwer` ([Truwer](https://github.com/Isithunzi000/arkadia-mudlet-truwer), a roleplay scene assistant for Arkadia MUD) for trusted publishing from [Isithunzi000/arkadia-mpackage](https://github.com/Isithunzi000/arkadia-mpackage).

Same repository and workflow (`.github/workflows/sync-publish.yml`) as the already registered entries `ishtar_cal`, `imperium_cal` and `pasek_kalendarz_arkadia`, with `ref` pinned to `refs/heads/main`.

The numeric ids were read from the API as suggested:

    $ curl -s https://api.github.com/repos/Isithunzi000/arkadia-mpackage | jq '.id, .owner.id'
    1346062051
    263814053

The package is not published yet, so nothing is published over: no `packages/truwer.mpackage` exists today, and no other entry names the `truwer.mpackage` filename.